### PR TITLE
Speficy subcrates version.

### DIFF
--- a/crates/cargo-lambda-cli/Cargo.toml
+++ b/crates/cargo-lambda-cli/Cargo.toml
@@ -15,10 +15,10 @@ keywords = ["cargo", "subcommand", "aws", "lambda"]
 # add the latest version of a dependency to the list,
 # and it will keep the alphabetic ordering for you.
 [dependencies]
-cargo-lambda-build = { path = "../cargo-lambda-build" }
-cargo-lambda-invoke = { path = "../cargo-lambda-invoke" }
-cargo-lambda-new = { path = "../cargo-lambda-new" }
-cargo-lambda-watch = { path = "../cargo-lambda-watch" }
+cargo-lambda-build = { version = "0.1.0", path = "../cargo-lambda-build" }
+cargo-lambda-invoke = { version = "0.1.0", path = "../cargo-lambda-invoke" }
+cargo-lambda-new = { version = "0.1.0", path = "../cargo-lambda-new" }
+cargo-lambda-watch = { version = "0.1.0", path = "../cargo-lambda-watch" }
 clap = { version = "3.1.8", features = ["cargo", "derive"] }
 miette = { version = "4.3.0", features = ["fancy"] }
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
Otherwise `cargo publish` fails.

Signed-off-by: David Calavera <david.calavera@gmail.com>