### PR TITLE
Release 0.6.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,12 @@ jobs:
           command: check
 
   test:
-    name: Test Suite
+    name: Test Suite -- ${{ matrix.rust_version }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
+        rust_version: ["1.59.0", "stable"]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -36,8 +37,9 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.rust_version }}
           override: true
+      - uses: Swatinem/rust-cache@v1
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,8 @@
+publish-all:
+    cargo publish --package crates/cargo-lambda-interactive
+    cargo publish --package crates/cargo-lambda-metadata
+    cargo publish --package crates/cargo-lambda-build
+    cargo publish --package crates/cargo-lambda-invoke
+    cargo publish --package crates/cargo-lambda-new
+    cargo publish --package crates/cargo-lambda-watch
+    cargo publish --package crates/cargo-lambda-cli

--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ cargo lambda invoke http-lambda --data-example apigw-request
 
 After the first download, these examples are cached in your home directory, under `.cargo/lambda/invoke-fixtures`.
 
+## Rust version
+
+This project works with Rust 1.59 and above.
+
 [//]: # 'badges'
 [crate-image]: https://img.shields.io/crates/v/cargo-lambda.svg
 [crate-link]: https://crates.io/crates/cargo-lambda

--- a/crates/cargo-lambda-build/Cargo.toml
+++ b/crates/cargo-lambda-build/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "cargo-lambda-build"
 description = "Cargo subcommand to work with AWS Lambda"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/cargo-lambda/cargo-lambda"
 repository = "https://github.com/cargo-lambda/cargo-lambda"
 keywords = ["cargo", "subcommand", "aws", "lambda"]
+rust-version = "1.59.0"
 
 # Use cargo-edit(https://github.com/killercup/cargo-edit#installation)
 # to manage dependencies.
@@ -15,8 +16,8 @@ keywords = ["cargo", "subcommand", "aws", "lambda"]
 # add the latest version of a dependency to the list,
 # and it will keep the alphabetic ordering for you.
 [dependencies]
-cargo-lambda-interactive = { version = "0.6.0", path = "../cargo-lambda-interactive" }
-cargo-lambda-metadata = { version = "0.6.0", path = "../cargo-lambda-metadata" }
+cargo-lambda-interactive = { version = "0.6", path = "../cargo-lambda-interactive" }
+cargo-lambda-metadata = { version = "0.6", path = "../cargo-lambda-metadata" }
 cargo-zigbuild = "0.8.1"
 clap = { version = "3.1.8", features = ["cargo", "derive"] }
 home = "0.5.3"

--- a/crates/cargo-lambda-build/README.md
+++ b/crates/cargo-lambda-build/README.md
@@ -1,5 +1,5 @@
 # cargo-lambda-build
 
-This is subcommand for [cargo-lambda](https://crates.io/crates/cargo-lambda).
+This is a subcommand for [cargo-lambda](https://crates.io/crates/cargo-lambda).
 
 This crate is not designed to work standalone, use [cargo-lambda](https://crates.io/crates/cargo-lambda) instead.

--- a/crates/cargo-lambda-cli/Cargo.toml
+++ b/crates/cargo-lambda-cli/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "cargo-lambda"
 description = "Cargo subcommand to work with AWS Lambda"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "MIT"
 readme = "../../README.md"
 homepage = "https://github.com/cargo-lambda/cargo-lambda"
 repository = "https://github.com/cargo-lambda/cargo-lambda"
 keywords = ["cargo", "subcommand", "aws", "lambda"]
+rust-version = "1.59.0"
 
 # Use cargo-edit(https://github.com/killercup/cargo-edit#installation)
 # to manage dependencies.

--- a/crates/cargo-lambda-interactive/Cargo.toml
+++ b/crates/cargo-lambda-interactive/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "cargo-lambda-interactive"
 description = "Cargo subcommand to work with AWS Lambda"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/cargo-lambda/cargo-lambda"
 repository = "https://github.com/cargo-lambda/cargo-lambda"
 keywords = ["cargo", "subcommand", "aws", "lambda"]
+rust-version = "1.59.0"
 
 # Use cargo-edit(https://github.com/killercup/cargo-edit#installation)
 # to manage dependencies.

--- a/crates/cargo-lambda-interactive/README.md
+++ b/crates/cargo-lambda-interactive/README.md
@@ -1,5 +1,5 @@
 # cargo-lambda-interactive
 
-This is subcommand for [cargo-lambda](https://crates.io/crates/cargo-lambda).
+This is a subcommand for [cargo-lambda](https://crates.io/crates/cargo-lambda).
 
 This crate is not designed to work standalone, use [cargo-lambda](https://crates.io/crates/cargo-lambda) instead.

--- a/crates/cargo-lambda-invoke/Cargo.toml
+++ b/crates/cargo-lambda-invoke/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "cargo-lambda-invoke"
 description = "Cargo subcommand to work with AWS Lambda"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/cargo-lambda/cargo-lambda"
 repository = "https://github.com/cargo-lambda/cargo-lambda"
 keywords = ["cargo", "subcommand", "aws", "lambda"]
+rust-version = "1.59.0"
 
 # Use cargo-edit(https://github.com/killercup/cargo-edit#installation)
 # to manage dependencies.

--- a/crates/cargo-lambda-invoke/README.md
+++ b/crates/cargo-lambda-invoke/README.md
@@ -1,5 +1,5 @@
 # cargo-lambda-invoke
 
-This is subcommand for [cargo-lambda](https://crates.io/crates/cargo-lambda).
+This is a subcommand for [cargo-lambda](https://crates.io/crates/cargo-lambda).
 
 This crate is not designed to work standalone, use [cargo-lambda](https://crates.io/crates/cargo-lambda) instead.

--- a/crates/cargo-lambda-metadata/Cargo.toml
+++ b/crates/cargo-lambda-metadata/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "cargo-lambda-metadata"
 description = "Cargo subcommand to work with AWS Lambda"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/cargo-lambda/cargo-lambda"
 repository = "https://github.com/cargo-lambda/cargo-lambda"
 keywords = ["cargo", "subcommand", "aws", "lambda"]
+rust-version = "1.59.0"
 
 # Use cargo-edit(https://github.com/killercup/cargo-edit#installation)
 # to manage dependencies.

--- a/crates/cargo-lambda-metadata/README.md
+++ b/crates/cargo-lambda-metadata/README.md
@@ -1,5 +1,5 @@
 # cargo-lambda-metadata
 
-This is subcommand for [cargo-lambda](https://crates.io/crates/cargo-lambda).
+This is a subcommand for [cargo-lambda](https://crates.io/crates/cargo-lambda).
 
 This crate is not designed to work standalone, use [cargo-lambda](https://crates.io/crates/cargo-lambda) instead.

--- a/crates/cargo-lambda-new/Cargo.toml
+++ b/crates/cargo-lambda-new/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "cargo-lambda-new"
 description = "Cargo subcommand to work with AWS Lambda"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/cargo-lambda/cargo-lambda"
 repository = "https://github.com/cargo-lambda/cargo-lambda"
 keywords = ["cargo", "subcommand", "aws", "lambda"]
+rust-version = "1.59.0"
 
 # Use cargo-edit(https://github.com/killercup/cargo-edit#installation)
 # to manage dependencies.
@@ -15,7 +16,7 @@ keywords = ["cargo", "subcommand", "aws", "lambda"]
 # add the latest version of a dependency to the list,
 # and it will keep the alphabetic ordering for you.
 [dependencies]
-cargo-lambda-interactive = { version = "0.6.0", path = "../cargo-lambda-interactive" }
+cargo-lambda-interactive = { version = "0.6", path = "../cargo-lambda-interactive" }
 clap = { version = "3.1.8", features = ["cargo", "derive"] }
 liquid = "0.26.0"
 miette = { version = "4.3.0", features = ["fancy"] }

--- a/crates/cargo-lambda-new/README.md
+++ b/crates/cargo-lambda-new/README.md
@@ -1,5 +1,5 @@
 # cargo-lambda-new
 
-This is subcommand for [cargo-lambda](https://crates.io/crates/cargo-lambda).
+This is a subcommand for [cargo-lambda](https://crates.io/crates/cargo-lambda).
 
 This crate is not designed to work standalone, use [cargo-lambda](https://crates.io/crates/cargo-lambda) instead.

--- a/crates/cargo-lambda-watch/Cargo.toml
+++ b/crates/cargo-lambda-watch/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "cargo-lambda-watch"
 description = "Cargo subcommand to work with AWS Lambda"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/cargo-lambda/cargo-lambda"
 repository = "https://github.com/cargo-lambda/cargo-lambda"
 keywords = ["cargo", "subcommand", "aws", "lambda"]
+rust-version = "1.59.0"
 
 # Use cargo-edit(https://github.com/killercup/cargo-edit#installation)
 # to manage dependencies.
@@ -16,9 +17,9 @@ keywords = ["cargo", "subcommand", "aws", "lambda"]
 # and it will keep the alphabetic ordering for you.
 [dependencies]
 axum = "0.5.1"
-cargo-lambda-interactive = { version = "0.6.0", path = "../cargo-lambda-interactive" }
-cargo-lambda-invoke = { version = "0.6.0", path = "../cargo-lambda-invoke" }
-cargo-lambda-metadata = { version = "0.6.0", path = "../cargo-lambda-metadata" }
+cargo-lambda-interactive = { version = "0.6", path = "../cargo-lambda-interactive" }
+cargo-lambda-invoke = { version = "0.6", path = "../cargo-lambda-invoke" }
+cargo-lambda-metadata = { version = "0.6", path = "../cargo-lambda-metadata" }
 clap = { version = "3.1.8", features = ["cargo", "derive"] }
 home = "0.5.3"
 http-api-problem = { version = "0.51.0", features = ["api-error", "hyper"] }

--- a/crates/cargo-lambda-watch/README.md
+++ b/crates/cargo-lambda-watch/README.md
@@ -1,5 +1,5 @@
 # cargo-lambda-watch
 
-This is subcommand for [cargo-lambda](https://crates.io/crates/cargo-lambda).
+This is a subcommand for [cargo-lambda](https://crates.io/crates/cargo-lambda).
 
 This crate is not designed to work standalone, use [cargo-lambda](https://crates.io/crates/cargo-lambda) instead.


### PR DESCRIPTION
- Set the minimum required Rust version.
-- This fixes installation messages because of compilation errors
on older versions of Rust.
- Run tests with the minimum and also the stable Rust versions.

Fixes #64

Signed-off-by: David Calavera <david.calavera@gmail.com>