### PR TITLE
Support for Lambda Function URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,10 +99,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "axum"
-version = "0.5.1"
+name = "aws_lambda_events"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47594e438a243791dba58124b6669561f5baa14cb12046641d8008bf035e5a25"
+checksum = "4c1e41ff8f5750dabfd3e940de42a12bdb842369d0985630a424db0a96721c6e"
+dependencies = [
+ "base64",
+ "bytes",
+ "chrono",
+ "http",
+ "http-body",
+ "http-serde",
+ "query_map",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "axum"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f523b4e98ba6897ae90994bc18423d9877c54f9047b06a00ddc8122a957b1c70"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -131,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a671c9ae99531afdd5d3ee8340b8da547779430689947144c140fc74a740244"
+checksum = "d3ddbd16eabff8b45f21b98671fddcc93daaa7ac4c84f8473693437226040de5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -229,6 +247,9 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bzip2"
@@ -343,18 +364,24 @@ dependencies = [
 name = "cargo-lambda-watch"
 version = "0.6.2"
 dependencies = [
+ "aws_lambda_events",
  "axum",
+ "base64",
  "cargo-lambda-interactive",
  "cargo-lambda-invoke",
  "cargo-lambda-metadata",
+ "chrono",
  "clap",
  "home",
  "http-api-problem",
+ "hyper",
  "miette",
  "opentelemetry",
  "opentelemetry-aws",
  "platforms",
+ "query_map",
  "reqwest",
+ "serde_json",
  "tar",
  "tempfile",
  "thiserror",
@@ -435,6 +462,20 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time 0.1.43",
+ "winapi",
+]
 
 [[package]]
 name = "cipher"
@@ -945,6 +986,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
+name = "http-serde"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d98b3d9662de70952b14c4840ee0f37e23973542a363e2275f4b9d024ff6cca"
+dependencies = [
+ "http",
+ "serde",
+]
+
+[[package]]
 name = "httparse"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,7 +1196,7 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde",
- "time",
+ "time 0.3.9",
 ]
 
 [[package]]
@@ -1170,7 +1221,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "regex",
- "time",
+ "time 0.3.9",
  "unicode-segmentation",
 ]
 
@@ -1342,6 +1393,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -1663,6 +1724,17 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "query_map"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9b3184a42d995e58fefd23c04d277a2b4d51efb5df7ad4efbe0a43d77b5923"
+dependencies = [
+ "form_urlencoded",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2256,6 +2328,16 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
@@ -2793,7 +2875,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1",
- "time",
+ "time 0.3.9",
  "zstd",
 ]
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,15 @@ name = "add-product"
 path = "src/bin/add-product.rs"
 ```
 
+#### Watch - Function URLs
+
+The emulator server includes support for [Lambda function URLs](https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html) out of the box. Since we're working locally, these URLs are under the `/lambda-url` path instead of under a subdomain. The function that you're trying to access through a URL must respond to Request events using [lambda_http](https://crates.io/crates/lambda_http/), or raw `ApiGatewayV2httpRequest` events.
+
+You can create functions compatible with this feature by running `cargo lambda new --http FUNCTION_NAME`.
+
+To access a function via its HTTP endpoint, start the watch subcommand `cargo lambda watch`, then send requests to the endpoint `http://localhost:9000/lambda-url/FUNCTION_NAME`. You can add any additional path after the function name, or any query parameters.
+
+
 ### Invoke
 
 The invoke subcomand helps you send requests to the control plane emulator.

--- a/crates/cargo-lambda-watch/Cargo.toml
+++ b/crates/cargo-lambda-watch/Cargo.toml
@@ -16,18 +16,24 @@ rust-version = "1.59.0"
 # add the latest version of a dependency to the list,
 # and it will keep the alphabetic ordering for you.
 [dependencies]
-axum = "0.5.1"
+aws_lambda_events = { version = "0.6.1", features = ["apigw"] }
+axum = "0.5.3"
+base64 = "0.13.0"
 cargo-lambda-interactive = { version = "0.6", path = "../cargo-lambda-interactive" }
 cargo-lambda-invoke = { version = "0.6", path = "../cargo-lambda-invoke" }
 cargo-lambda-metadata = { version = "0.6", path = "../cargo-lambda-metadata" }
+chrono = "0.4.19"
 clap = { version = "3.1.8", features = ["cargo", "derive"] }
 home = "0.5.3"
 http-api-problem = { version = "0.51.0", features = ["api-error", "hyper"] }
+hyper = "0.14.18"
 miette = { version = "4.3.0", features = ["fancy"] }
 opentelemetry = "0.17.0"
 opentelemetry-aws = "0.5.0"
 platforms = "2.0.0"
+query_map = { version = "0.4.0", features = ["url-query"] }
 reqwest = { version = "0.11.10", default-features = false, features = ["rustls-tls"] }
+serde_json = "1.0.79"
 tempfile = "3.3.0"
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["sync", "time"] }

--- a/crates/cargo-lambda-watch/src/requests.rs
+++ b/crates/cargo-lambda-watch/src/requests.rs
@@ -40,6 +40,18 @@ pub enum ServerError {
     #[error("invalid request id header")]
     #[diagnostic()]
     InvalidRequestIdHeader(#[from] axum::http::header::ToStrError),
+
+    #[error("failed to deserialize the request body")]
+    #[diagnostic()]
+    BodyDeserialization(#[from] hyper::Error),
+
+    #[error("failed to deserialize the request body")]
+    #[diagnostic()]
+    StringBody(#[from] std::string::FromUtf8Error),
+
+    #[error("failed to serialize lambda-url event")]
+    #[diagnostic()]
+    SerializationError(#[from] serde_json::Error),
 }
 
 impl IntoResponse for ServerError {

--- a/crates/cargo-lambda-watch/src/runtime_router.rs
+++ b/crates/cargo-lambda-watch/src/runtime_router.rs
@@ -1,0 +1,121 @@
+use crate::requests::*;
+use crate::scheduler::*;
+use axum::{
+    body::Body,
+    extract::{Extension, Path},
+    http::{Request, StatusCode},
+    response::Response,
+    routing::{get, post},
+    Router,
+};
+use tracing::debug;
+
+pub(crate) const LAMBDA_RUNTIME_AWS_REQUEST_ID: &str = "lambda-runtime-aws-request-id";
+pub(crate) const LAMBDA_RUNTIME_CLIENT_CONTEXT: &str = "lambda-runtime-client-context";
+pub(crate) const LAMBDA_RUNTIME_COGNITO_IDENTITY: &str = "lambda-runtime-cognito-identity";
+pub(crate) const LAMBDA_RUNTIME_DEADLINE_MS: &str = "lambda-runtime-deadline-ms";
+pub(crate) const LAMBDA_RUNTIME_FUNCTION_ARN: &str = "lambda-runtime-invoked-function-arn";
+pub(crate) const LAMBDA_RUNTIME_XRAY_TRACE_HEADER: &str = "lambda-runtime-trace-id";
+
+pub(crate) fn routes() -> Router {
+    Router::new()
+        .route(
+            "/:function_name/2018-06-01/runtime/invocation/next",
+            get(next_request),
+        )
+        .route(
+            "/:function_name/2018-06-01/runtime/invocation/:req_id/response",
+            post(next_invocation_response),
+        )
+        .route(
+            "/:function_name/2018-06-01/runtime/invocation/:req_id/error",
+            post(next_invocation_error),
+        )
+}
+
+async fn next_request(
+    Extension(req_cache): Extension<RequestCache>,
+    Extension(resp_cache): Extension<ResponseCache>,
+    Path(function_name): Path<String>,
+    req: Request<Body>,
+) -> Result<Response<Body>, ServerError> {
+    let req_id = req
+        .headers()
+        .get(LAMBDA_RUNTIME_AWS_REQUEST_ID)
+        .expect("missing request id");
+
+    let mut builder = Response::builder()
+        .header(LAMBDA_RUNTIME_AWS_REQUEST_ID, req_id)
+        .header(LAMBDA_RUNTIME_DEADLINE_MS, 600_000_u32)
+        .header(LAMBDA_RUNTIME_FUNCTION_ARN, "function-arn");
+
+    let resp = match req_cache.pop(&function_name).await {
+        None => builder.status(StatusCode::NO_CONTENT).body(Body::empty()),
+        Some(invoke) => {
+            let req_id = req_id
+                .to_str()
+                .map_err(ServerError::InvalidRequestIdHeader)?;
+
+            debug!(req_id = ?req_id, "processing request");
+
+            let (parts, body) = invoke.req.into_parts();
+
+            let resp_tx = invoke.resp_tx;
+            resp_cache.push(req_id, resp_tx).await;
+
+            let headers = parts.headers;
+            if let Some(h) = headers.get(LAMBDA_RUNTIME_CLIENT_CONTEXT) {
+                builder = builder.header(LAMBDA_RUNTIME_CLIENT_CONTEXT, h);
+            }
+            if let Some(h) = headers.get(LAMBDA_RUNTIME_COGNITO_IDENTITY) {
+                builder = builder.header(LAMBDA_RUNTIME_COGNITO_IDENTITY, h);
+            }
+            if let Some(h) = headers.get(LAMBDA_RUNTIME_XRAY_TRACE_HEADER) {
+                builder = builder.header(LAMBDA_RUNTIME_XRAY_TRACE_HEADER, h);
+            }
+
+            builder.status(StatusCode::OK).body(body)
+        }
+    };
+
+    resp.map_err(ServerError::ResponseBuild)
+}
+
+async fn next_invocation_response(
+    Extension(cache): Extension<ResponseCache>,
+    Path((_function_name, req_id)): Path<(String, String)>,
+    req: Request<Body>,
+) -> Result<Response<Body>, ServerError> {
+    respond_to_next_invocation(&cache, &req_id, req, StatusCode::OK).await
+}
+
+async fn next_invocation_error(
+    Extension(cache): Extension<ResponseCache>,
+    Path((_function_name, req_id)): Path<(String, String)>,
+    req: Request<Body>,
+) -> Result<Response<Body>, ServerError> {
+    respond_to_next_invocation(&cache, &req_id, req, StatusCode::INTERNAL_SERVER_ERROR).await
+}
+
+async fn respond_to_next_invocation(
+    cache: &ResponseCache,
+    req_id: &str,
+    req: Request<Body>,
+    response_status: StatusCode,
+) -> Result<Response<Body>, ServerError> {
+    if let Some(resp_tx) = cache.pop(req_id).await {
+        let (_, body) = req.into_parts();
+
+        let resp = Response::builder()
+            .status(response_status)
+            .header(LAMBDA_RUNTIME_AWS_REQUEST_ID, req_id)
+            .body(body)
+            .map_err(ServerError::ResponseBuild)?;
+
+        resp_tx
+            .send(resp)
+            .map_err(|_| ServerError::SendFunctionMessage)?;
+    }
+
+    Ok(Response::new(Body::empty()))
+}

--- a/crates/cargo-lambda-watch/src/trigger_router.rs
+++ b/crates/cargo-lambda-watch/src/trigger_router.rs
@@ -1,0 +1,211 @@
+use crate::requests::*;
+use crate::runtime_router::{LAMBDA_RUNTIME_AWS_REQUEST_ID, LAMBDA_RUNTIME_XRAY_TRACE_HEADER};
+use aws_lambda_events::{
+    apigw::{
+        ApiGatewayV2httpRequest, ApiGatewayV2httpRequestContext,
+        ApiGatewayV2httpRequestContextHttpDescription, ApiGatewayV2httpResponse,
+    },
+    encodings::Body as LambdaBody,
+};
+use axum::{
+    body::Body,
+    extract::{Extension, Path},
+    http::Request,
+    response::Response,
+    routing::{any, post},
+    Router,
+};
+use cargo_lambda_invoke::DEFAULT_PACKAGE_FUNCTION;
+use chrono::Utc;
+use hyper::body::to_bytes;
+use miette::Result;
+use opentelemetry::{
+    global,
+    trace::{TraceContextExt, Tracer},
+    Context, KeyValue,
+};
+use query_map::QueryMap;
+use std::collections::HashMap;
+use tokio::sync::{mpsc::Sender, oneshot};
+
+const AWS_XRAY_TRACE_HEADER: &str = "x-amzn-trace-id";
+
+pub(crate) fn routes() -> Router {
+    Router::new()
+        .route(
+            "/2015-03-31/functions/:function_name/invocations",
+            post(invoke_handler),
+        )
+        .route("/lambda-url/:function_name/*path", any(furls_handler))
+}
+
+async fn furls_handler(
+    Extension(cmd_tx): Extension<Sender<InvokeRequest>>,
+    Path((function_name, path)): Path<(String, String)>,
+    req: Request<Body>,
+) -> Result<Response<Body>, ServerError> {
+    let (parts, body) = req.into_parts();
+    let uri = &parts.uri;
+    let headers = &parts.headers;
+
+    let body = to_bytes(body)
+        .await
+        .map_err(ServerError::BodyDeserialization)?;
+    let text_content_type = match headers.get("content-type") {
+        None => true,
+        Some(c) => {
+            let c = c.to_str().unwrap_or_default();
+            c.starts_with("text/") || c.starts_with("application/json")
+        }
+    };
+
+    let (body, is_base64_encoded) = if body.is_empty() {
+        (None, false)
+    } else if text_content_type {
+        let body =
+            String::from_utf8(body.into_iter().collect()).map_err(ServerError::StringBody)?;
+        (Some(body), false)
+    } else {
+        let body = base64::encode(body.into_iter().collect::<Vec<u8>>());
+        (Some(body), true)
+    };
+
+    let query_string_parameters = uri
+        .query()
+        .unwrap_or_default()
+        .parse::<QueryMap>()
+        .unwrap_or_default();
+
+    let cookies = headers.get("cookie").map(|c| {
+        c.to_str()
+            .unwrap_or_default()
+            .split("; ")
+            .map(|s| s.trim().to_string())
+            .collect()
+    });
+
+    let req_id = headers
+        .get(LAMBDA_RUNTIME_AWS_REQUEST_ID)
+        .expect("missing request id")
+        .to_str()
+        .expect("invalid request id format");
+
+    let time = Utc::now();
+    let path = format!("/{}", path);
+
+    let request_context = ApiGatewayV2httpRequestContext {
+        stage: Some("$default".into()),
+        route_key: Some("$default".into()),
+        request_id: Some(req_id.into()),
+        domain_name: Some("localhost".into()),
+        domain_prefix: Some(function_name.clone()),
+        http: ApiGatewayV2httpRequestContextHttpDescription {
+            method: parts.method.clone(),
+            path: Some(path.clone()),
+            protocol: Some("http".into()),
+            source_ip: Some("127.0.0.1".into()),
+            user_agent: Some("cargo-lamba".into()),
+        },
+        time: Some(time.format("%d/%b/%Y:%T %z").to_string()),
+        time_epoch: time.timestamp(),
+        account_id: None,
+        authorizer: None,
+        authentication: None,
+        apiid: None,
+    };
+
+    let event = ApiGatewayV2httpRequest {
+        version: Some("2.0".into()),
+        route_key: Some("$default".into()),
+        raw_path: Some(path),
+        raw_query_string: uri.query().map(String::from),
+        path_parameters: HashMap::new(),
+        stage_variables: HashMap::new(),
+        headers: headers.clone(),
+        body,
+        request_context,
+        cookies,
+        query_string_parameters,
+        is_base64_encoded,
+    };
+    let event = serde_json::to_string(&event).map_err(ServerError::SerializationError)?;
+
+    let req = Request::from_parts(parts, event.into());
+    let mut resp = schedule_invocation(&cmd_tx, function_name, req).await?;
+
+    let body = to_bytes(resp.body_mut())
+        .await
+        .map_err(ServerError::BodyDeserialization)?;
+    let resp_event: ApiGatewayV2httpResponse =
+        serde_json::from_slice(&body).map_err(ServerError::SerializationError)?;
+
+    let resp_body = match resp_event.body.unwrap_or(LambdaBody::Empty) {
+        LambdaBody::Empty => Body::empty(),
+        LambdaBody::Text(s) => Body::from(s),
+        LambdaBody::Binary(b) => Body::from(b),
+    };
+    let mut builder = Response::builder().status(resp_event.status_code as u16);
+    if let Some(headers) = builder.headers_mut() {
+        headers.extend(resp_event.headers);
+        headers.extend(resp_event.multi_value_headers);
+    }
+
+    builder.body(resp_body).map_err(ServerError::ResponseBuild)
+}
+
+async fn invoke_handler(
+    Extension(cmd_tx): Extension<Sender<InvokeRequest>>,
+    Path(function_name): Path<String>,
+    req: Request<Body>,
+) -> Result<Response<Body>, ServerError> {
+    schedule_invocation(&cmd_tx, function_name, req).await
+}
+
+async fn schedule_invocation(
+    cmd_tx: &Sender<InvokeRequest>,
+    function_name: String,
+    mut req: Request<Body>,
+) -> Result<Response<Body>, ServerError> {
+    let headers = req.headers_mut();
+
+    let span = global::tracer("cargo-lambda/emulator").start("invoke request");
+    let cx = Context::current_with_span(span);
+
+    let mut injector = HashMap::new();
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&cx, &mut injector);
+    });
+    let xray_header = injector
+        .get(AWS_XRAY_TRACE_HEADER)
+        .expect("x-amzn-trace-id header not injected by the propagator") // this is Infaliable
+        .parse()
+        .expect("x-amzn-trace-id header is not in the expected format"); // this is Infaliable
+    headers.insert(LAMBDA_RUNTIME_XRAY_TRACE_HEADER, xray_header);
+
+    let (resp_tx, resp_rx) = oneshot::channel::<Response<Body>>();
+    let function_name = if function_name.is_empty() || function_name == "_" {
+        DEFAULT_PACKAGE_FUNCTION.into()
+    } else {
+        function_name
+    };
+
+    let req = InvokeRequest {
+        function_name,
+        req,
+        resp_tx,
+    };
+
+    cmd_tx
+        .send(req)
+        .await
+        .map_err(|e| ServerError::SendInvokeMessage(Box::new(e)))?;
+
+    let resp = resp_rx.await.map_err(ServerError::ReceiveFunctionMessage)?;
+
+    cx.span().add_event(
+        "function call completed",
+        vec![KeyValue::new("status", resp.status().to_string())],
+    );
+
+    Ok(resp)
+}


### PR DESCRIPTION
Lambda just launched a feature that allows you to reach
HTTP functions via unique URLs.

The payload that those functions receive are from Api Gateway V2 events.

This change adds support for a similar functionality, using
subpaths instead of subdomains.

Signed-off-by: David Calavera <david.calavera@gmail.com>