### PR TITLE
rename no longer uses io::ErrorKind::Other

### DIFF
--- a/crates/cargo-lambda-metadata/src/fs/rename_linux.rs
+++ b/crates/cargo-lambda-metadata/src/fs/rename_linux.rs
@@ -37,15 +37,13 @@ where
 {
     match fs::rename(&from, &to) {
         Ok(ok) => Ok(ok),
-        Err(e) => match e.kind() {
-            io::ErrorKind::Other if Some(libc::EXDEV) == e.raw_os_error() => {
-                match copy_and_delete(from, to) {
-                    Ok(()) => Ok(()),
-                    Err(_) => Err(e),
-                }
+        Err(e) if Some(libc::EXDEV) == e.raw_os_error() => {
+            match copy_and_delete(from, to) {
+                Ok(()) => Ok(()),
+                Err(_) => Err(e),
             }
-            _ => Err(e),
         },
+        Err(e) => Err(e),
     }
 }
 


### PR DESCRIPTION
io::ErrorKind::Other no longer gets returned by std as of https://github.com/rust-lang/rust/pull/85746
In lieu of requiring the io_error_more feature, match against the raw_os_error directly

Fixes https://github.com/cargo-lambda/cargo-lambda/issues/70