### PR TITLE
Update arm flag to match the name in other tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ By default, cargo-lambda compiles the code for Linux X86-64 architectures, you c
 cargo lambda build --target aarch64-unknown-linux-gnu
 ```
 
-ℹ️ Starting in version 0.7.0, you can use the shortcut `--arm` to compile your functions for Linux ARM architectures:
+ℹ️ Starting in version 0.6.2, you can use the shortcut `--arm64` to compile your functions for Linux ARM architectures:
 
 ```
-cargo lambda build --arm
+cargo lambda build --arm64
 ```
 
 #### Build - Compilation Profiles

--- a/crates/cargo-lambda-build/src/lib.rs
+++ b/crates/cargo-lambda-build/src/lib.rs
@@ -25,7 +25,7 @@ pub struct Build {
 
     /// Shortcut for --target aarch64-unknown-linux-gnu
     #[clap(long)]
-    arm: bool,
+    arm64: bool,
 
     #[clap(flatten)]
     build: ZigBuild,
@@ -49,13 +49,13 @@ impl Build {
         let host_target = &rustc_meta.host;
         let release_channel = &rustc_meta.channel;
 
-        if self.arm && !self.build.target.is_empty() {
+        if self.arm64 && !self.build.target.is_empty() {
             return Err(miette::miette!(
                 "invalid options: --arm and --target cannot be specified at the same time"
             ));
         }
 
-        if self.arm {
+        if self.arm64 {
             self.build.target = vec![TARGET_ARM.into()];
         }
 


### PR DESCRIPTION
SAM and the CDK use arm_64 as identifiers. Follow this convention.

Signed-off-by: David Calavera <david.calavera@gmail.com>