### PR TITLE
Pin internal dependencies.

### DIFF
--- a/crates/cargo-lambda-build/Cargo.toml
+++ b/crates/cargo-lambda-build/Cargo.toml
@@ -16,8 +16,8 @@ rust-version = "1.59.0"
 # add the latest version of a dependency to the list,
 # and it will keep the alphabetic ordering for you.
 [dependencies]
-cargo-lambda-interactive = { version = "0.7", path = "../cargo-lambda-interactive" }
-cargo-lambda-metadata = { version = "0.7", path = "../cargo-lambda-metadata" }
+cargo-lambda-interactive = { version = "0.7.0", path = "../cargo-lambda-interactive" }
+cargo-lambda-metadata = { version = "0.7.0", path = "../cargo-lambda-metadata" }
 cargo-zigbuild = "0.8.6"
 clap = { version = "3.1.8", features = ["derive"] }
 home = "0.5.3"

--- a/crates/cargo-lambda-cli/Cargo.toml
+++ b/crates/cargo-lambda-cli/Cargo.toml
@@ -16,11 +16,11 @@ rust-version = "1.59.0"
 # add the latest version of a dependency to the list,
 # and it will keep the alphabetic ordering for you.
 [dependencies]
-cargo-lambda-build = { version = "0.7", path = "../cargo-lambda-build" }
-cargo-lambda-deploy = { version = "0.7", path = "../cargo-lambda-deploy" }
-cargo-lambda-invoke = { version = "0.7", path = "../cargo-lambda-invoke" }
-cargo-lambda-new = { version = "0.7", path = "../cargo-lambda-new" }
-cargo-lambda-watch = { version = "0.7", path = "../cargo-lambda-watch" }
+cargo-lambda-build = { version = "0.7.0", path = "../cargo-lambda-build" }
+cargo-lambda-deploy = { version = "0.7.1", path = "../cargo-lambda-deploy" }
+cargo-lambda-invoke = { version = "0.7.0", path = "../cargo-lambda-invoke" }
+cargo-lambda-new = { version = "0.7.0", path = "../cargo-lambda-new" }
+cargo-lambda-watch = { version = "0.7.0", path = "../cargo-lambda-watch" }
 clap = { version = "3.1.8", features = ["derive", "suggestions"] }
 miette = { version = "4.3.0", features = ["fancy"] }
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }

--- a/crates/cargo-lambda-deploy/Cargo.toml
+++ b/crates/cargo-lambda-deploy/Cargo.toml
@@ -12,10 +12,10 @@ keywords = ["cargo", "subcommand", "aws", "lambda"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cargo-lambda-build = { version = "0.7", path = "../cargo-lambda-build" }
-cargo-lambda-interactive = { version = "0.7", path = "../cargo-lambda-interactive" }
-cargo-lambda-metadata = { version = "0.7", path = "../cargo-lambda-metadata" }
-cargo-lambda-remote = { version = "0.7", path = "../cargo-lambda-remote" }
+cargo-lambda-build = { version = "0.7.0", path = "../cargo-lambda-build" }
+cargo-lambda-interactive = { version = "0.7.0", path = "../cargo-lambda-interactive" }
+cargo-lambda-metadata = { version = "0.7.0", path = "../cargo-lambda-metadata" }
+cargo-lambda-remote = { version = "0.7.0", path = "../cargo-lambda-remote" }
 clap = { version = "3.1.8", features = ["derive"] }
 miette = "4.5.0"
 strum = "0.24.0"

--- a/crates/cargo-lambda-invoke/Cargo.toml
+++ b/crates/cargo-lambda-invoke/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.59.0"
 # add the latest version of a dependency to the list,
 # and it will keep the alphabetic ordering for you.
 [dependencies]
-cargo-lambda-remote = { version = "0.7", path = "../cargo-lambda-remote" }
+cargo-lambda-remote = { version = "0.7.0", path = "../cargo-lambda-remote" }
 clap = { version = "3.1.8", features = ["derive"] }
 home = "0.5.3"
 miette = "4.5.0"

--- a/crates/cargo-lambda-new/Cargo.toml
+++ b/crates/cargo-lambda-new/Cargo.toml
@@ -16,8 +16,8 @@ rust-version = "1.59.0"
 # add the latest version of a dependency to the list,
 # and it will keep the alphabetic ordering for you.
 [dependencies]
-cargo-lambda-interactive = { version = "0.7", path = "../cargo-lambda-interactive" }
-cargo-lambda-metadata = { version = "0.7", path = "../cargo-lambda-metadata" }
+cargo-lambda-interactive = { version = "0.7.0", path = "../cargo-lambda-interactive" }
+cargo-lambda-metadata = { version = "0.7.0", path = "../cargo-lambda-metadata" }
 clap = { version = "3.1.8", features = ["derive"] }
 liquid = "0.26.0"
 miette = "4.5.0"

--- a/crates/cargo-lambda-watch/Cargo.toml
+++ b/crates/cargo-lambda-watch/Cargo.toml
@@ -19,9 +19,9 @@ rust-version = "1.59.0"
 aws_lambda_events = { version = "0.6.2", features = ["apigw"] }
 axum = "0.5.4"
 base64 = "0.13.0"
-cargo-lambda-interactive = { version = "0.7", path = "../cargo-lambda-interactive" }
-cargo-lambda-invoke = { version = "0.7", path = "../cargo-lambda-invoke" }
-cargo-lambda-metadata = { version = "0.7", path = "../cargo-lambda-metadata" }
+cargo-lambda-interactive = { version = "0.7.0", path = "../cargo-lambda-interactive" }
+cargo-lambda-invoke = { version = "0.7.0", path = "../cargo-lambda-invoke" }
+cargo-lambda-metadata = { version = "0.7.0", path = "../cargo-lambda-metadata" }
 chrono = "0.4.19"
 clap = { version = "3.1.8", features = ["derive"] }
 home = "0.5.3"


### PR DESCRIPTION
This makes it easier to ensure that published crates have all the expected internal versions.

Signed-off-by: David Calavera <david.calavera@gmail.com>