### PR TITLE
Build & Deploy Lambda extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,9 +100,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77fa6e51f756ca6a0b1732e2cffde895d1e967e595c444e1a4e11aac92437dd"
+checksum = "f91154572c69defdbe4ee7e7c86a0d1ad1f8c49655bedb7c6be61a7c1dc43105"
 dependencies = [
  "aws-http",
  "aws-sdk-sso",
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "aws-endpoint"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb9486b31d996a309594b3491ae752dbe807d1d13731f5718d37a2ccfe4bdf11"
+checksum = "515bd0f038107827309daa28612941ff559e71a6e96335e336d4fdf4caffb34b"
 dependencies = [
  "aws-smithy-http",
  "aws-types",
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "aws-http"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b0c6a0938ee38f5f7659d8b175d151f75cf64f856bbde2f1aabb4d3d6f79be"
+checksum = "1378c2c2430a063076621ec8c6435cdbd97b3e053111aebb52c9333fc793f32c"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lambda"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9fd8d1dd9c6c870d7e829f052efe15e14d7fa379d7f9a8a0b3a6a3d3908850"
+checksum = "72d7faff830fb1dcb701b369723a874abd1086906f79ae2aa34d23345d9fcae9"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -176,10 +176,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-sso"
-version = "0.10.1"
+name = "aws-sdk-s3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c446f905f10fe8306186eac98eb6304366c2db0310ceeb0d441769a264bf0fa"
+checksum = "25e2c859c7420c8564b6eb964056abf508c10c0269cbd624ecc8c8de5c33446c"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "http",
+ "md5",
+ "tokio-stream",
+ "tower",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d74bff9a790eceb16a7825b11c4d9526fe6d3649349ba04beb5cb4770b7822b4"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -199,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b41d5d00307f0c5a2195ee0f11bb9414e5e88b9a8cbced191b0c04196c3f0da"
+checksum = "e879f3619e0b444218ab76d28364d57b81820ad792fd58088ab675237e4d7b5f"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -221,11 +246,12 @@ dependencies = [
 
 [[package]]
 name = "aws-sig-auth"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c2bd9951d37869431a9c21c5e2319baaf549f41045e8eb891fb3de5bde3ec7"
+checksum = "b44c7698294a89fabbadb538560ad34b6fdd26e926dee3c5e710928c3093fcf0"
 dependencies = [
  "aws-sigv4",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-types",
  "http",
@@ -235,11 +261,13 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcfa45ad4f4d00e7d4f770c6f760ffde6b1fb409ed30e0577361f00d903a0895"
+checksum = "2fe0aee7539298b8447e1a60d2d6de329fb1619f116c5f488e0b3aa136d49696"
 dependencies = [
+ "aws-smithy-eventstream",
  "aws-smithy-http",
+ "bytes",
  "form_urlencoded",
  "hex",
  "http",
@@ -253,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.40.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235f5e604c23992ca08892d0762bc1be9c166912f109597ec80220dd698277ff"
+checksum = "23dcbf7d119f514a627d236412626645c4378b126e30dc61db9de3e069fa1676"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -265,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-client"
-version = "0.40.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666694cbd62dd2892ddfdcb8f3b416b0425705ec0f0114d76ddd50c9c16be948"
+checksum = "511ac6c65f2a89cfcd74fe78aa6d07216095a53cbaeab493b17f6df82cd65b86"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -288,11 +316,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-http"
-version = "0.40.2"
+name = "aws-smithy-eventstream"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06512ad2d8e80dcddb67859ed482ff433e2a2769228b980c1403d2cb069e365"
+checksum = "703e7d99d80156d5a41a3996a985701650ccb0d5edaf441ca40bda199d34284e"
 dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d800c8684fa567cdf1abd9654c7997b2a887e7b06022938756193472ec7ec251"
+dependencies = [
+ "aws-smithy-eventstream",
  "aws-smithy-types",
  "bytes",
  "bytes-utils",
@@ -310,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-tower"
-version = "0.40.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cc242962fc624a942cd9d9341007f3a28d94d72ba4eaed82754126e19c7327"
+checksum = "8017959786cce64e690214d303d062c97fcd38a68df7cb444255e534c9bbce49"
 dependencies = [
  "aws-smithy-http",
  "bytes",
@@ -325,18 +365,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.40.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb575dc48946d75a55a28137fce1ae2b94fd75b82ddad7d67760b0613a08068"
+checksum = "3796e2a4a3b7d15db2fd5aec2de9220919332648f0a56a77b5c53caf4a9653fa"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.40.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1f71d4f1c9f2cb0aded4d27c9dc5d55f5398372e0e19a9d489b80ab0bcdb80"
+checksum = "76694d1a2dacefa347b921c61bf64b5cc493a898971b3c18fa636ce1788ceabe"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -344,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "0.40.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540e9d7f6d9655b17d2a794b0a54322359754fea3357a60f6d9c7cf1bc7ff0f2"
+checksum = "7c7f957a2250cc0fa4ccf155e00aeac9a81f600df7cd4ecc910c75030e6534f5"
 dependencies = [
  "itoa",
  "num-integer",
@@ -356,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.40.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431df835bfa2cce08535bb8735a9a8b2fc0fed7c52ed16506c9c430dc18aa7e"
+checksum = "1b01d77433f248d9a2b08f519b403d6aa8435bf144b5d8585862f8dd599eb843"
 dependencies = [
  "thiserror",
  "xmlparser",
@@ -366,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a1ae75d090d4cd44b2fe1d2de1783ff8665f2f0e3957f5e99c1a5760a77a0a"
+checksum = "394d5c945b747ab3292b94509b78c91191aacfd1deacbcd58371d6f61f8be78a"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-client",
@@ -610,12 +650,15 @@ dependencies = [
 name = "cargo-lambda-deploy"
 version = "0.7.3"
 dependencies = [
+ "aws-sdk-s3",
  "cargo-lambda-build",
  "cargo-lambda-interactive",
  "cargo-lambda-metadata",
  "cargo-lambda-remote",
  "clap",
  "miette",
+ "serde",
+ "serde_json",
  "strum",
  "strum_macros",
  "tokio",
@@ -680,6 +723,7 @@ version = "0.7.3"
 dependencies = [
  "aws-config",
  "aws-sdk-lambda",
+ "aws-types",
  "clap",
 ]
 
@@ -1661,6 +1705,12 @@ name = "matchit"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ The example below deploys a function that has already been compiled with the def
 cargo lambda deploy --iam-role FULL_ROLE_ARN http-lambda
 ```
 
-### Deploy - Function URLs
+#### Deploy - Function URLs
 
 This subcommand can enable Lambda function URLs for your lambda. Use the flag `--enable-function-url` when you deploy your function, and when the operation completes, the command will print the function URL in the terminal.
 
@@ -269,7 +269,7 @@ cargo lambda deploy --iam-role FULL_ROLE_ARN --enable-function-url http-lambda
 
 You can use the flag `--disable-function-url` if you want to disable the function URL.
 
-### Deploy - Environment variables
+#### Deploy - Environment variables
 
 You can add environment variables to a function during deployment with the flags `--env-var` and `--env-file`.
 
@@ -287,11 +287,20 @@ The flag `--env-file` will read the variables from a file and add them to the fu
 cargo lambda deploy --iam-role FULL_ROLE_ARN --env-file .env http-lambda
 ```
 
-### Deploy - Other options
+#### Deploy - Extensions
+
+cargo-lambda can deploy Lambda Extensions built in Rust by adding the `--extension` flag to the `deploy` command. This command requires you to build the extension first with the same `--extension` flag in the `build` command:
+
+```
+cargo lambda build --release --extension
+cargo lambda deploy --extension
+```
+
+#### Deploy - Other options
 
 Use the `--help` flag to see other options to configure the function's deployment.
 
-### Deploy - State management
+#### Deploy - State management
 
 ⚠️ The deploy command doesn't use any kind of state management. If you require state management, you should use tools like [SAM Cli](https://github.com/aws/aws-sam-cli) or the [AWS CDK](https://github.com/aws/aws-cdk).
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ cargo lambda build --release
 
 When you compile your code in release mode, cargo-lambda will strip the binaries from all debug symbols to reduce the binary size.
 
+#### Build - Extensions
+
+cargo-lambda can also build Lambda Extensions written in Rust. If you want to build a extension, use the flag `--extension` to put the output under `target/lambda/extensions`, so you don't mix extensions and functions.
+
+```
+cargo lambda build --release --extension
+```
+
+If you want to create a zip file with the structure that AWS Lambda expects to find extensions in, add the `--output-format` flag to the previous command, and cargo-lambda will zip the extensions directory with your extension inside.
+
+```
+cargo lambda build --release --extension --output-format zip
+```
+
 #### Build - How does it work?
 
 cargo-lambda uses [Zig](https://ziglang.org) and [cargo-zigbuild](https://crates.io/crates/cargo-zigbuild)

--- a/crates/cargo-lambda-build/src/lib.rs
+++ b/crates/cargo-lambda-build/src/lib.rs
@@ -10,6 +10,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use strum_macros::EnumString;
+use zip::{write::FileOptions, ZipWriter};
 
 mod toolchain;
 mod zig;
@@ -17,7 +18,7 @@ mod zig;
 #[derive(Args, Clone, Debug)]
 #[clap(name = "build")]
 pub struct Build {
-    /// The format to produce the compile Lambda into, acceptable values are [Binary, Zip].
+    /// The format to produce the compile Lambda into, acceptable values are [Binary, Zip]
     #[clap(long, default_value_t = OutputFormat::Binary)]
     output_format: OutputFormat,
 
@@ -28,6 +29,10 @@ pub struct Build {
     /// Shortcut for --target aarch64-unknown-linux-gnu
     #[clap(long)]
     arm64: bool,
+
+    /// Whether the code that you're building is a Lambda Extension
+    #[clap(long)]
+    extension: bool,
 
     #[clap(flatten)]
     build: ZigBuild,
@@ -156,14 +161,30 @@ impl Build {
         for name in &binaries {
             let binary = base.join(name);
             if binary.exists() {
-                let bootstrap_dir = lambda_dir.join(name);
+                let bootstrap_dir = if self.extension {
+                    lambda_dir.join("extensions")
+                } else {
+                    lambda_dir.join(name)
+                };
                 create_dir_all(&bootstrap_dir).into_diagnostic()?;
+
+                let bin_name = if self.extension {
+                    name.as_str()
+                } else {
+                    "bootstrap"
+                };
+
                 match self.output_format {
                     OutputFormat::Binary => {
-                        rename(binary, bootstrap_dir.join("bootstrap")).into_diagnostic()?;
+                        rename(binary, bootstrap_dir.join(bin_name)).into_diagnostic()?;
                     }
                     OutputFormat::Zip => {
-                        zip_binary(binary, bootstrap_dir)?;
+                        let parent = if self.extension {
+                            Some("extensions")
+                        } else {
+                            None
+                        };
+                        zip_binary(bin_name, binary, bootstrap_dir, parent)?;
                     }
                 }
             }
@@ -218,15 +239,20 @@ pub fn find_function_archive<P: AsRef<Path>>(
         ));
     }
 
-    zip_binary(binary_path, bootstrap_dir)
+    zip_binary("bootstrap", binary_path, bootstrap_dir, None)
 }
 
 /// Create a zip file from a function binary.
 /// The binary inside the zip file is always called `bootstrap`.
-fn zip_binary<P: AsRef<Path>>(binary_path: P, destination_directory: P) -> Result<BinaryArchive> {
+fn zip_binary<P: AsRef<Path>>(
+    name: &str,
+    binary_path: P,
+    destination_directory: P,
+    parent: Option<&str>,
+) -> Result<BinaryArchive> {
     let path = binary_path.as_ref();
     let dir = destination_directory.as_ref();
-    let zipped = dir.join("bootstrap.zip");
+    let zipped = dir.join(format!("{}.zip", name));
 
     let zipped_binary = File::create(&zipped).into_diagnostic()?;
     let binary_data = read(path).into_diagnostic()?;
@@ -243,9 +269,20 @@ fn zip_binary<P: AsRef<Path>>(binary_path: P, destination_directory: P) -> Resul
     hasher.update(binary_data);
     let sha256 = format!("{:X}", hasher.finalize());
 
-    let mut zip = zip::ZipWriter::new(zipped_binary);
-    zip.start_file("bootstrap", Default::default())
-        .into_diagnostic()?;
+    let mut zip = ZipWriter::new(zipped_binary);
+    let file_name = if let Some(parent) = parent {
+        zip.add_directory(parent, FileOptions::default())
+            .into_diagnostic()?;
+        Path::new(parent).join(name)
+    } else {
+        PathBuf::from(name)
+    };
+
+    zip.start_file(
+        file_name.to_str().expect("failed to convert file path"),
+        Default::default(),
+    )
+    .into_diagnostic()?;
     zip.write_all(binary_data).into_diagnostic()?;
     zip.finish().into_diagnostic()?;
 

--- a/crates/cargo-lambda-deploy/Cargo.toml
+++ b/crates/cargo-lambda-deploy/Cargo.toml
@@ -12,12 +12,15 @@ keywords = ["cargo", "subcommand", "aws", "lambda"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+aws-sdk-s3 = "0.11.0"
 cargo-lambda-build = { version = "0.7.3", path = "../cargo-lambda-build" }
 cargo-lambda-interactive = { version = "0.7.3", path = "../cargo-lambda-interactive" }
 cargo-lambda-metadata = { version = "0.7.3", path = "../cargo-lambda-metadata" }
 cargo-lambda-remote = { version = "0.7.3", path = "../cargo-lambda-remote" }
 clap = { version = "3.1.17", features = ["derive"] }
 miette = "4.7.0"
+serde = { version = "1.0.137", features = ["derive"] }
+serde_json = "1.0.81"
 strum = "0.24.0"
 strum_macros = "0.24.0"
 tokio = { version = "1.18.1", default-features = false, features = ["time"]}

--- a/crates/cargo-lambda-deploy/src/extensions.rs
+++ b/crates/cargo-lambda-deploy/src/extensions.rs
@@ -1,0 +1,77 @@
+use super::DeployResult;
+use aws_sdk_s3::{types::ByteStream, Client as S3Client};
+use cargo_lambda_interactive::progress::Progress;
+use cargo_lambda_remote::{
+    aws_sdk_config::SdkConfig,
+    aws_sdk_lambda::{
+        model::{Architecture, LayerVersionContentInput, Runtime},
+        types::Blob,
+        Client as LambdaClient,
+    },
+};
+use miette::{IntoDiagnostic, Result, WrapErr};
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub(crate) struct DeployOutput {
+    extension_arn: String,
+}
+
+impl std::fmt::Display for DeployOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "🔍 extension arn: {}", self.extension_arn)
+    }
+}
+
+pub(crate) async fn deploy(
+    name: &str,
+    sdk_config: &SdkConfig,
+    binary_data: Vec<u8>,
+    architecture: Architecture,
+    s3_bucket: &Option<String>,
+    progress: &Progress,
+) -> Result<DeployResult> {
+    let lambda_client = LambdaClient::new(sdk_config);
+
+    let input = match s3_bucket {
+        None => LayerVersionContentInput::builder()
+            .zip_file(Blob::new(binary_data))
+            .build(),
+        Some(bucket) => {
+            progress.set_message("uploading binary to S3");
+
+            let s3_client = S3Client::new(sdk_config);
+            s3_client
+                .put_object()
+                .bucket(bucket)
+                .key(name)
+                .body(ByteStream::from(binary_data))
+                .send()
+                .await
+                .into_diagnostic()
+                .wrap_err("failed to upload extension code to S3")?;
+
+            LayerVersionContentInput::builder()
+                .s3_bucket(bucket)
+                .s3_key(name)
+                .build()
+        }
+    };
+
+    progress.set_message("publishing new layer version");
+
+    let output = lambda_client
+        .publish_layer_version()
+        .layer_name(name)
+        .compatible_architectures(architecture)
+        .compatible_runtimes(Runtime::Providedal2)
+        .content(input)
+        .send()
+        .await
+        .into_diagnostic()
+        .wrap_err("failed to publish extension")?;
+
+    Ok(DeployResult::Extension(DeployOutput {
+        extension_arn: output.layer_version_arn.expect("missing ARN"),
+    }))
+}

--- a/crates/cargo-lambda-deploy/src/functions.rs
+++ b/crates/cargo-lambda-deploy/src/functions.rs
@@ -1,0 +1,558 @@
+use super::DeployResult;
+use aws_sdk_s3::{types::ByteStream, Client as S3Client};
+use cargo_lambda_interactive::progress::Progress;
+use cargo_lambda_remote::{
+    aws_sdk_config::SdkConfig,
+    aws_sdk_lambda::{
+        error::{
+            DeleteFunctionUrlConfigError, GetAliasError, GetFunctionError,
+            GetFunctionUrlConfigError,
+        },
+        model::{
+            Architecture, Environment, FunctionCode, FunctionConfiguration, FunctionUrlAuthType,
+            Runtime, State, TracingConfig,
+        },
+        output::GetFunctionOutput,
+        types::{Blob, SdkError},
+        Client as LambdaClient,
+    },
+    RemoteConfig,
+};
+use clap::{Args, ValueHint};
+use miette::{IntoDiagnostic, Result, WrapErr};
+use serde::Serialize;
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+    path::PathBuf,
+};
+use strum_macros::{Display, EnumString};
+use tokio::time::{sleep, Duration};
+
+enum FunctionAction {
+    Create,
+    Update(Box<GetFunctionOutput>),
+}
+
+#[derive(Clone, Debug, Display, EnumString)]
+#[strum(ascii_case_insensitive)]
+pub enum Tracing {
+    Active,
+    Passthrough,
+}
+
+#[derive(Args, Clone, Debug)]
+pub struct FunctionDeployConfig {
+    /// Memory allocated for the function
+    #[clap(long)]
+    pub memory_size: Option<i32>,
+
+    /// Enable function URL for this function
+    #[clap(long)]
+    pub enable_function_url: bool,
+
+    /// Disable function URL for this function
+    #[clap(long)]
+    pub disable_function_url: bool,
+
+    /// How long the function can be running for, in seconds
+    #[clap(long, default_value = "30")]
+    pub timeout: i32,
+
+    /// Option to add one or many environment variables, allows multiple repetitions
+    /// Use VAR_KEY=VAR_VALUE as format
+    #[clap(long)]
+    pub env_var: Option<Vec<String>>,
+
+    /// Read environment variables from a file
+    #[clap(long, value_hint = ValueHint::FilePath)]
+    pub env_file: Option<PathBuf>,
+
+    /// Tracing mode with X-Ray
+    #[clap(long, default_value_t = Tracing::Active)]
+    pub tracing: Tracing,
+
+    /// IAM Role associated with the function
+    #[clap(long)]
+    pub iam_role: Option<String>,
+
+    /// Lambda Layer ARN to associate the deployed function with
+    #[clap(long)]
+    pub layer_arn: Option<Vec<String>>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct DeployOutput {
+    function_arn: String,
+    function_url: Option<String>,
+}
+
+impl std::fmt::Display for DeployOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "🔍 function arn: {}", self.function_arn)?;
+        if let Some(url) = &self.function_url {
+            write!(f, "🔗 function url: {}", url)?;
+        }
+        Ok(())
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn deploy(
+    name: &str,
+    function_config: &FunctionDeployConfig,
+    remote_config: &RemoteConfig,
+    sdk_config: &SdkConfig,
+    s3_bucket: &Option<String>,
+    binary_data: Vec<u8>,
+    architecture: Architecture,
+    progress: &Progress,
+) -> Result<DeployResult> {
+    let client = LambdaClient::new(sdk_config);
+
+    progress.set_message("deploying function code");
+
+    let (function_arn, version) = upsert_function(
+        name,
+        &client,
+        function_config,
+        remote_config,
+        sdk_config,
+        s3_bucket,
+        binary_data,
+        architecture,
+    )
+    .await?;
+
+    if let Some(alias) = &remote_config.alias {
+        progress.set_message("updating alias version");
+
+        upsert_alias(name, alias, &version, &client).await?;
+    }
+
+    let function_url = if function_config.enable_function_url {
+        progress.set_message("configuring function url");
+
+        upsert_function_url_config(name, &remote_config.alias, &client).await?
+    } else {
+        None
+    };
+
+    if function_config.disable_function_url {
+        progress.set_message("deleting function url configuration");
+
+        delete_function_url_config(name, &remote_config.alias, &client).await?;
+    }
+
+    Ok(DeployResult::Function(DeployOutput {
+        function_arn,
+        function_url,
+    }))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn upsert_function(
+    name: &str,
+    client: &LambdaClient,
+    function_config: &FunctionDeployConfig,
+    remote_config: &RemoteConfig,
+    sdk_config: &SdkConfig,
+    s3_bucket: &Option<String>,
+    binary_data: Vec<u8>,
+    architecture: Architecture,
+) -> Result<(String, String)> {
+    let current_function = client.get_function().function_name(name).send().await;
+
+    let action = match current_function {
+        Ok(fun) => FunctionAction::Update(Box::new(fun)),
+        Err(no_fun) if function_doesnt_exist_error(&no_fun) => FunctionAction::Create,
+        Err(no_fun) => {
+            return Err(no_fun)
+                .into_diagnostic()
+                .wrap_err("failed to fetch lambda function")
+        }
+    };
+
+    let tracing_config = TracingConfig::builder()
+        .mode(function_config.tracing.to_string().as_str().into())
+        .build();
+
+    let iam_role = function_config.iam_role.clone();
+
+    let (arn, version) = match action {
+        FunctionAction::Create => {
+            let code = match &s3_bucket {
+                None => {
+                    let blob = Blob::new(binary_data);
+                    FunctionCode::builder().zip_file(blob).build()
+                }
+                Some(bucket) => {
+                    let client = S3Client::new(sdk_config);
+                    client
+                        .put_object()
+                        .bucket(bucket)
+                        .key(name)
+                        .body(ByteStream::from(binary_data))
+                        .send()
+                        .await
+                        .into_diagnostic()
+                        .wrap_err("failed to upload function code to S3")?;
+                    FunctionCode::builder()
+                        .s3_bucket(bucket)
+                        .s3_key(name)
+                        .build()
+                }
+            };
+
+            let output = client
+                .create_function()
+                .runtime(Runtime::Providedal2)
+                .handler("bootstrap")
+                .function_name(name)
+                .set_role(iam_role)
+                .architectures(architecture)
+                .code(code)
+                .publish(true)
+                .set_memory_size(function_config.memory_size)
+                .timeout(function_config.timeout)
+                .tracing_config(tracing_config)
+                .environment(function_environment(
+                    &function_config.env_file,
+                    &function_config.env_var,
+                )?)
+                .set_layers(function_config.layer_arn.clone())
+                .send()
+                .await
+                .into_diagnostic()
+                .wrap_err("failed to create new lambda function")?;
+
+            (output.function_arn, output.version)
+        }
+        FunctionAction::Update(fun) => {
+            if let Some(conf) = fun.configuration {
+                let mut builder = client
+                    .update_function_configuration()
+                    .function_name(name)
+                    .set_role(iam_role);
+
+                let mut update_config = false;
+                if function_config.memory_size.is_some()
+                    && conf.memory_size != function_config.memory_size
+                {
+                    update_config = true;
+                    builder = builder.set_memory_size(function_config.memory_size);
+                }
+                if conf.timeout.unwrap_or_default() != function_config.timeout {
+                    update_config = true;
+                    builder = builder.timeout(function_config.timeout);
+                }
+
+                if should_update_layers(&function_config.layer_arn, &conf) {
+                    update_config = true;
+                    builder = builder.set_layers(function_config.layer_arn.clone());
+                }
+
+                let env =
+                    function_environment(&function_config.env_file, &function_config.env_var)?;
+                if env.variables != conf.environment.map(|e| e.variables).unwrap_or_default() {
+                    update_config = true;
+                    builder = builder.environment(env);
+                }
+
+                if tracing_config.mode != conf.tracing_config.map(|t| t.mode).unwrap_or_default() {
+                    update_config = true;
+                    builder = builder.tracing_config(tracing_config);
+                }
+
+                if update_config {
+                    builder
+                        .send()
+                        .await
+                        .into_diagnostic()
+                        .wrap_err("failed to update function configuration")?;
+
+                    // wait until the update has been conpletely propagated
+                    for attempt in 1..4 {
+                        let conf = client
+                            .get_function_configuration()
+                            .function_name(name)
+                            .set_qualifier(remote_config.alias.clone())
+                            .send()
+                            .await
+                            .into_diagnostic()
+                            .wrap_err("failed to fetch the function configuration")?;
+
+                        match &conf.state {
+                            Some(state) => match state {
+                                State::Active => break,
+                                State::Pending => {
+                                    sleep(Duration::from_secs(attempt * attempt)).await;
+                                }
+                                other => {
+                                    return Err(miette::miette!(
+                                        "unexpected function state: {:?}",
+                                        other
+                                    ))
+                                }
+                            },
+                            None => return Err(miette::miette!("unknown function state")),
+                        }
+
+                        if attempt == 3 {
+                            return Err(miette::miette!("configuration update didn't finish in time, wait a few minutes and try again"));
+                        }
+                    }
+                }
+            }
+
+            let mut builder = client.update_function_code().function_name(name);
+
+            match &s3_bucket {
+                None => {
+                    let blob = Blob::new(binary_data);
+                    builder = builder.zip_file(blob)
+                }
+                Some(bucket) => {
+                    let client = S3Client::new(sdk_config);
+                    client
+                        .put_object()
+                        .bucket(bucket)
+                        .key(name)
+                        .body(ByteStream::from(binary_data))
+                        .send()
+                        .await
+                        .into_diagnostic()
+                        .wrap_err("failed to upload function code to S3")?;
+
+                    builder = builder.s3_bucket(bucket).s3_key(name);
+                }
+            }
+
+            let output = builder
+                .publish(true)
+                .send()
+                .await
+                .into_diagnostic()
+                .wrap_err("failed to update function code")?;
+
+            (output.function_arn, output.version)
+        }
+    };
+
+    Ok((
+        arn.expect("missing function ARN"),
+        version.expect("missing function version"),
+    ))
+}
+
+pub(crate) fn should_update_layers(
+    layer_arn: &Option<Vec<String>>,
+    conf: &FunctionConfiguration,
+) -> bool {
+    match (conf.layers(), layer_arn) {
+        (None, None) => false,
+        (Some(_), None) => true,
+        (None, Some(_)) => true,
+        (Some(cl), Some(nl)) => {
+            let mut c = cl
+                .iter()
+                .cloned()
+                .map(|l| l.arn.unwrap_or_default())
+                .collect::<Vec<_>>();
+            c.sort();
+
+            let mut n = nl.to_vec();
+            n.sort();
+            c != n
+        }
+    }
+}
+
+pub(crate) async fn upsert_alias(
+    name: &str,
+    alias: &str,
+    version: &str,
+    client: &LambdaClient,
+) -> Result<()> {
+    let current_alias = client
+        .get_alias()
+        .name(alias)
+        .function_name(name)
+        .send()
+        .await;
+
+    match current_alias {
+        Ok(_) => {
+            client
+                .update_alias()
+                .name(alias)
+                .function_name(name)
+                .function_version(version)
+                .send()
+                .await
+                .into_diagnostic()
+                .wrap_err("failed to update alias")?;
+        }
+        Err(no_fun) if alias_doesnt_exist_error(&no_fun) => {
+            client
+                .create_alias()
+                .name(alias)
+                .function_name(name)
+                .function_version(version)
+                .send()
+                .await
+                .into_diagnostic()
+                .wrap_err("failed to create alias")?;
+        }
+        Err(no_fun) => {
+            return Err(no_fun)
+                .into_diagnostic()
+                .wrap_err("failed to fetch alias")
+        }
+    };
+
+    Ok(())
+}
+
+pub(crate) async fn upsert_function_url_config(
+    name: &str,
+    alias: &Option<String>,
+    client: &LambdaClient,
+) -> Result<Option<String>> {
+    let result = client
+        .get_function_url_config()
+        .function_name(name)
+        .set_qualifier(alias.clone())
+        .send()
+        .await;
+
+    let url = match result {
+        Ok(fun) => fun.function_url,
+        Err(no_fun) if function_url_config_doesnt_exist_error(&no_fun) => {
+            client
+                .add_permission()
+                .function_name(name)
+                .set_qualifier(alias.clone())
+                .action("lambda:InvokeFunctionUrl")
+                .principal("*")
+                .statement_id("FunctionUrlAllowPublicAccess")
+                .function_url_auth_type(FunctionUrlAuthType::None)
+                .send()
+                .await
+                .into_diagnostic()
+                .wrap_err("failed to enable function url invocations")?;
+
+            let output = client
+                .create_function_url_config()
+                .function_name(name)
+                .auth_type(FunctionUrlAuthType::None)
+                .set_qualifier(alias.clone())
+                .send()
+                .await
+                .into_diagnostic()
+                .wrap_err("failed to create function url configuration")?;
+            output.function_url
+        }
+        Err(no_fun) => {
+            return Err(no_fun)
+                .into_diagnostic()
+                .wrap_err("failed to fetch function url configuration")?;
+        }
+    };
+
+    Ok(url)
+}
+
+pub(crate) async fn delete_function_url_config(
+    name: &str,
+    alias: &Option<String>,
+    client: &LambdaClient,
+) -> Result<()> {
+    let result = client
+        .delete_function_url_config()
+        .function_name(name)
+        .set_qualifier(alias.clone())
+        .send()
+        .await;
+
+    match result {
+        Ok(_) => Ok(()),
+        Err(no_fun) if delete_function_url_config_doesnt_exist_error(&no_fun) => Ok(()),
+        Err(no_fun) => Err(no_fun)
+            .into_diagnostic()
+            .wrap_err("failed to delete function url configuration"),
+    }
+}
+
+pub(crate) fn function_environment(
+    env_file: &Option<PathBuf>,
+    env_vars: &Option<Vec<String>>,
+) -> Result<Environment> {
+    let mut env = Environment::builder();
+    if let Some(path) = env_file {
+        let file = File::open(path)
+            .into_diagnostic()
+            .wrap_err("failed to open env file: {path}")?;
+        let reader = BufReader::new(file);
+
+        for line in reader.lines() {
+            let line = line.into_diagnostic().wrap_err("failed to read env line")?;
+
+            let mut iter = line.trim().splitn(2, '=');
+            let key = iter
+                .next()
+                .ok_or_else(|| miette::miette!("invalid env variable {var}"))?;
+            let value = iter
+                .next()
+                .ok_or_else(|| miette::miette!("invalid env variable {var}"))?;
+            env = env.variables(key, value);
+        }
+    }
+
+    if let Some(vars) = env_vars {
+        for var in vars {
+            let mut iter = var.trim().splitn(2, '=');
+            let key = iter
+                .next()
+                .ok_or_else(|| miette::miette!("invalid env variable {var}"))?;
+            let value = iter
+                .next()
+                .ok_or_else(|| miette::miette!("invalid env variable {var}"))?;
+            env = env.variables(key, value);
+        }
+    }
+
+    Ok(env.build())
+}
+
+pub(crate) fn function_doesnt_exist_error(err: &SdkError<GetFunctionError>) -> bool {
+    match err {
+        SdkError::ServiceError { err, .. } => err.is_resource_not_found_exception(),
+        _ => false,
+    }
+}
+
+pub(crate) fn function_url_config_doesnt_exist_error(
+    err: &SdkError<GetFunctionUrlConfigError>,
+) -> bool {
+    match err {
+        SdkError::ServiceError { err, .. } => err.is_resource_not_found_exception(),
+        _ => false,
+    }
+}
+
+pub(crate) fn delete_function_url_config_doesnt_exist_error(
+    err: &SdkError<DeleteFunctionUrlConfigError>,
+) -> bool {
+    match err {
+        SdkError::ServiceError { err, .. } => err.is_resource_not_found_exception(),
+        _ => false,
+    }
+}
+
+pub(crate) fn alias_doesnt_exist_error(err: &SdkError<GetAliasError>) -> bool {
+    match err {
+        SdkError::ServiceError { err, .. } => err.is_resource_not_found_exception(),
+        _ => false,
+    }
+}

--- a/crates/cargo-lambda-deploy/src/lib.rs
+++ b/crates/cargo-lambda-deploy/src/lib.rs
@@ -1,58 +1,48 @@
-use cargo_lambda_build::{find_function_archive, BinaryArchive};
+use cargo_lambda_build::find_binary_archive;
 use cargo_lambda_interactive::progress::Progress;
 use cargo_lambda_metadata::cargo::root_package;
-use cargo_lambda_remote::{
-    aws_sdk_lambda::{
-        error::{
-            DeleteFunctionUrlConfigError, GetAliasError, GetFunctionError,
-            GetFunctionUrlConfigError,
-        },
-        model::{
-            Architecture, Environment, FunctionCode, FunctionConfiguration, FunctionUrlAuthType,
-            Runtime, State, TracingConfig,
-        },
-        output::GetFunctionOutput,
-        types::{Blob, SdkError},
-        Client,
-    },
-    init_client, RemoteConfig,
-};
+use cargo_lambda_remote::{aws_sdk_lambda::model::Architecture, RemoteConfig};
 use clap::{Args, ValueHint};
 use miette::{IntoDiagnostic, Result, WrapErr};
-use std::{
-    fs::{read, File},
-    io::{BufRead, BufReader},
-    path::PathBuf,
-};
+use serde::Serialize;
+use serde_json::ser::to_string_pretty;
+use std::{fs::read, path::PathBuf};
 use strum_macros::{Display, EnumString};
-use tokio::time::{sleep, Duration};
 
-enum FunctionAction {
-    Create,
-    Update(Box<GetFunctionOutput>),
+mod extensions;
+mod functions;
+
+#[derive(Clone, Debug, Display, EnumString)]
+#[strum(ascii_case_insensitive)]
+enum OutputFormat {
+    Text,
+    Json,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+enum DeployResult {
+    Extension(extensions::DeployOutput),
+    Function(functions::DeployOutput),
+}
+
+impl std::fmt::Display for DeployResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DeployResult::Extension(o) => o.fmt(f),
+            DeployResult::Function(o) => o.fmt(f),
+        }
+    }
 }
 
 #[derive(Args, Clone, Debug)]
 #[clap(name = "deploy")]
 pub struct Deploy {
     #[clap(flatten)]
-    config: RemoteConfig,
+    remote_config: RemoteConfig,
 
-    /// Memory allocated for the function
-    #[clap(long)]
-    memory_size: Option<i32>,
-
-    /// Enable function URL for this function
-    #[clap(long)]
-    enable_function_url: bool,
-
-    /// Disable function URL for this function
-    #[clap(long)]
-    disable_function_url: bool,
-
-    /// How long the function can be running for, in seconds
-    #[clap(long, default_value = "30")]
-    timeout: i32,
+    #[clap(flatten)]
+    function_config: functions::FunctionDeployConfig,
 
     /// Directory where the lambda binaries are located
     #[clap(short, long, value_hint = ValueHint::DirPath)]
@@ -71,56 +61,38 @@ pub struct Deploy {
     #[clap(long)]
     pub binary_name: Option<String>,
 
-    /// Option to add one or many environment variables, allows multiple repetitions
-    /// Use VAR_KEY=VAR_VALUE as format
+    /// S3 bucket to upload the code to
     #[clap(long)]
-    pub env_var: Option<Vec<String>>,
+    pub s3_bucket: Option<String>,
 
-    /// Read environment variables from a file
-    #[clap(long, value_hint = ValueHint::FilePath)]
-    pub env_file: Option<PathBuf>,
-
-    /// Tracing mode with X-Ray
-    #[clap(long, default_value_t = Tracing::Active)]
-    pub tracing: Tracing,
-
-    /// IAM Role associated with the function
+    /// Whether the code that you're building is a Lambda Extension
     #[clap(long)]
-    pub iam_role: Option<String>,
+    extension: bool,
 
-    /// Lambda Layer ARN to associate the deployed function with
-    #[clap(long)]
-    pub layer_arn: Option<Vec<String>>,
+    /// Format to render the output (text, or json)
+    #[clap(long, default_value_t = OutputFormat::Text)]
+    output_format: OutputFormat,
 
-    /// Name of the binary to deploy
-    #[clap(value_name = "FUNCTION_NAME")]
-    function_name: Option<String>,
-}
-
-#[derive(Clone, Debug, Display, EnumString)]
-#[strum(ascii_case_insensitive)]
-pub enum Tracing {
-    Active,
-    Passthrough,
+    /// Name of the function or extension to deploy
+    #[clap(value_name = "NAME")]
+    name: Option<String>,
 }
 
 impl Deploy {
     pub async fn run(&self) -> Result<()> {
-        if self.enable_function_url && self.disable_function_url {
+        if self.function_config.enable_function_url && self.function_config.disable_function_url {
             return Err(miette::miette!("invalid options: --enable-function-url and --disable-function-url cannot be set together"));
         }
 
-        let name = match &self.function_name {
+        let name = match &self.name {
             Some(name) => name.clone(),
             None => root_package(&self.manifest_path)?.name,
         };
         let binary_name = self.binary_name.as_deref().unwrap_or(&name);
 
-        let client = init_client(&self.config).await;
+        let progress = Progress::start("loading binary data");
 
-        let progress = Progress::start("deploying function");
-
-        let archive = match find_function_archive(binary_name, &self.lambda_dir) {
+        let archive = match find_binary_archive(binary_name, &self.lambda_dir, self.extension) {
             Ok(arc) => arc,
             Err(err) => {
                 progress.finish_and_clear();
@@ -128,393 +100,50 @@ impl Deploy {
             }
         };
 
-        let version = match self.upsert_function(&client, &name, &archive).await {
-            Ok(version) => version,
-            Err(err) => {
-                progress.finish_and_clear();
-                return Err(err);
-            }
-        };
+        let sdk_config = self.remote_config.to_sdk_config().await;
+        let architecture = Architecture::from(archive.architecture.as_str());
 
-        if let Some(alias) = &self.config.alias {
-            progress.set_message("updating alias version");
-
-            if let Err(err) = upsert_alias(&client, &name, alias, &version).await {
-                progress.finish_and_clear();
-                return Err(err);
-            }
-        }
-
-        let url = if self.enable_function_url {
-            progress.set_message("configuring function url");
-
-            match self.upsert_function_url_config(&client, &name).await {
-                Ok(url) => url,
-                Err(err) => {
-                    progress.finish_and_clear();
-                    return Err(err);
-                }
-            }
-        } else {
-            None
-        };
-
-        if self.disable_function_url {
-            progress.set_message("deleting function url configuration");
-
-            if let Err(err) = self.delete_function_url_config(&client, &name).await {
-                progress.finish_and_clear();
-                return Err(err);
-            }
-        }
-
-        progress.finish("done");
-        if let Some(url) = url {
-            println!("🔗 function url: {}", url);
-        }
-
-        Ok(())
-    }
-
-    async fn upsert_function(
-        &self,
-        client: &Client,
-        name: &str,
-        archive: &BinaryArchive,
-    ) -> Result<String> {
         let binary_data = read(&archive.path)
             .into_diagnostic()
             .wrap_err("failed to read binary archive")?;
-        let blob = Blob::new(binary_data);
 
-        let current_function = client.get_function().function_name(name).send().await;
-
-        let action = match current_function {
-            Ok(fun) => FunctionAction::Update(Box::new(fun)),
-            Err(no_fun) if function_doesnt_exist_error(&no_fun) => FunctionAction::Create,
-            Err(no_fun) => {
-                return Err(no_fun)
-                    .into_diagnostic()
-                    .wrap_err("failed to fetch lambda function")
-            }
+        let result = if self.extension {
+            extensions::deploy(
+                &name,
+                &sdk_config,
+                binary_data,
+                architecture,
+                &self.s3_bucket,
+                &progress,
+            )
+            .await
+        } else {
+            functions::deploy(
+                &name,
+                &self.function_config,
+                &self.remote_config,
+                &sdk_config,
+                &self.s3_bucket,
+                binary_data,
+                architecture,
+                &progress,
+            )
+            .await
         };
 
-        let tracing_config = TracingConfig::builder()
-            .mode(self.tracing.to_string().as_str().into())
-            .build();
+        progress.finish_and_clear();
+        let output = result?;
 
-        let iam_role = self.iam_role.clone();
-
-        let version = match action {
-            FunctionAction::Create => {
-                let code = FunctionCode::builder().zip_file(blob).build();
-
-                let output = client
-                    .create_function()
-                    .runtime(Runtime::Providedal2)
-                    .handler("bootstrap")
-                    .function_name(name)
-                    .set_role(iam_role)
-                    .architectures(Architecture::from(archive.architecture.as_str()))
-                    .code(code)
-                    .publish(true)
-                    .set_memory_size(self.memory_size)
-                    .timeout(self.timeout)
-                    .tracing_config(tracing_config)
-                    .environment(self.function_environment()?)
-                    .set_layers(self.layer_arn.clone())
-                    .send()
-                    .await
+        match &self.output_format {
+            OutputFormat::Text => println!("{output}"),
+            OutputFormat::Json => {
+                let text = to_string_pretty(&output)
                     .into_diagnostic()
-                    .wrap_err("failed to create new lambda function")?;
-
-                output.version
-            }
-            FunctionAction::Update(fun) => {
-                if let Some(conf) = fun.configuration {
-                    let mut builder = client
-                        .update_function_configuration()
-                        .function_name(name)
-                        .set_role(iam_role);
-
-                    let mut update_config = false;
-                    if self.memory_size.is_some() && conf.memory_size != self.memory_size {
-                        update_config = true;
-                        builder = builder.set_memory_size(self.memory_size);
-                    }
-                    if conf.timeout.unwrap_or_default() != self.timeout {
-                        update_config = true;
-                        builder = builder.timeout(self.timeout);
-                    }
-
-                    if self.update_layers(&conf) {
-                        update_config = true;
-                        builder = builder.set_layers(self.layer_arn.clone());
-                    }
-
-                    let env = self.function_environment()?;
-                    if env.variables != conf.environment.map(|e| e.variables).unwrap_or_default() {
-                        update_config = true;
-                        builder = builder.environment(env);
-                    }
-
-                    if tracing_config.mode
-                        != conf.tracing_config.map(|t| t.mode).unwrap_or_default()
-                    {
-                        update_config = true;
-                        builder = builder.tracing_config(tracing_config);
-                    }
-
-                    if update_config {
-                        builder
-                            .send()
-                            .await
-                            .into_diagnostic()
-                            .wrap_err("failed to update function configuration")?;
-
-                        // wait until the update has been conpletely propagated
-                        for attempt in 1..4 {
-                            let conf = client
-                                .get_function_configuration()
-                                .function_name(name)
-                                .set_qualifier(self.config.alias.clone())
-                                .send()
-                                .await
-                                .into_diagnostic()
-                                .wrap_err("failed to fetch the function configuration")?;
-
-                            match &conf.state {
-                                Some(state) => match state {
-                                    State::Active => break,
-                                    State::Pending => {
-                                        sleep(Duration::from_secs(attempt * attempt)).await;
-                                    }
-                                    other => {
-                                        return Err(miette::miette!(
-                                            "unexpected function state: {:?}",
-                                            other
-                                        ))
-                                    }
-                                },
-                                None => return Err(miette::miette!("unknown function state")),
-                            }
-
-                            if attempt == 3 {
-                                return Err(miette::miette!("configuration update didn't finish in time, wait a few minutes and try again"));
-                            }
-                        }
-                    }
-                }
-
-                let output = client
-                    .update_function_code()
-                    .function_name(name)
-                    .zip_file(blob)
-                    .publish(true)
-                    .send()
-                    .await
-                    .into_diagnostic()
-                    .wrap_err("failed to update function code")?;
-
-                output.version
-            }
-        };
-
-        Ok(version.unwrap_or_default())
-    }
-
-    async fn upsert_function_url_config(
-        &self,
-        client: &Client,
-        name: &str,
-    ) -> Result<Option<String>> {
-        let result = client
-            .get_function_url_config()
-            .function_name(name)
-            .set_qualifier(self.config.alias.clone())
-            .send()
-            .await;
-
-        let url = match result {
-            Ok(fun) => fun.function_url,
-            Err(no_fun) if function_url_config_doesnt_exist_error(&no_fun) => {
-                client
-                    .add_permission()
-                    .function_name(name)
-                    .set_qualifier(self.config.alias.clone())
-                    .action("lambda:InvokeFunctionUrl")
-                    .principal("*")
-                    .statement_id("FunctionUrlAllowPublicAccess")
-                    .function_url_auth_type(FunctionUrlAuthType::None)
-                    .send()
-                    .await
-                    .into_diagnostic()
-                    .wrap_err("failed to enable function url invocations")?;
-
-                let output = client
-                    .create_function_url_config()
-                    .function_name(name)
-                    .auth_type(FunctionUrlAuthType::None)
-                    .set_qualifier(self.config.alias.clone())
-                    .send()
-                    .await
-                    .into_diagnostic()
-                    .wrap_err("failed to create function url configuration")?;
-                output.function_url
-            }
-            Err(no_fun) => {
-                return Err(no_fun)
-                    .into_diagnostic()
-                    .wrap_err("failed to fetch function url configuration")?;
-            }
-        };
-
-        Ok(url)
-    }
-
-    async fn delete_function_url_config(&self, client: &Client, name: &str) -> Result<()> {
-        let result = client
-            .delete_function_url_config()
-            .function_name(name)
-            .set_qualifier(self.config.alias.clone())
-            .send()
-            .await;
-
-        match result {
-            Ok(_) => Ok(()),
-            Err(no_fun) if delete_function_url_config_doesnt_exist_error(&no_fun) => Ok(()),
-            Err(no_fun) => Err(no_fun)
-                .into_diagnostic()
-                .wrap_err("failed to delete function url configuration"),
-        }
-    }
-
-    fn function_environment(&self) -> Result<Environment> {
-        let mut env = Environment::builder();
-        if let Some(path) = &self.env_file {
-            let file = File::open(path)
-                .into_diagnostic()
-                .wrap_err("failed to open env file: {path}")?;
-            let reader = BufReader::new(file);
-
-            for line in reader.lines() {
-                let line = line.into_diagnostic().wrap_err("failed to read env line")?;
-
-                let mut iter = line.trim().splitn(2, '=');
-                let key = iter
-                    .next()
-                    .ok_or_else(|| miette::miette!("invalid env variable {var}"))?;
-                let value = iter
-                    .next()
-                    .ok_or_else(|| miette::miette!("invalid env variable {var}"))?;
-                env = env.variables(key, value);
+                    .wrap_err("failed to serialize output into json")?;
+                println!("{text}")
             }
         }
 
-        if let Some(vars) = &self.env_var {
-            for var in vars {
-                let mut iter = var.trim().splitn(2, '=');
-                let key = iter
-                    .next()
-                    .ok_or_else(|| miette::miette!("invalid env variable {var}"))?;
-                let value = iter
-                    .next()
-                    .ok_or_else(|| miette::miette!("invalid env variable {var}"))?;
-                env = env.variables(key, value);
-            }
-        }
-
-        Ok(env.build())
-    }
-
-    fn update_layers(&self, conf: &FunctionConfiguration) -> bool {
-        match (conf.layers(), &self.layer_arn) {
-            (None, None) => false,
-            (Some(_), None) => true,
-            (None, Some(_)) => true,
-            (Some(cl), Some(nl)) => {
-                let mut c = cl
-                    .iter()
-                    .cloned()
-                    .map(|l| l.arn.unwrap_or_default())
-                    .collect::<Vec<_>>();
-                c.sort();
-
-                let mut n = nl.to_vec();
-                n.sort();
-                c != n
-            }
-        }
-    }
-}
-
-async fn upsert_alias(client: &Client, name: &str, alias: &str, version: &str) -> Result<()> {
-    let current_alias = client
-        .get_alias()
-        .name(alias)
-        .function_name(name)
-        .send()
-        .await;
-
-    match current_alias {
-        Ok(_) => {
-            client
-                .update_alias()
-                .name(alias)
-                .function_name(name)
-                .function_version(version)
-                .send()
-                .await
-                .into_diagnostic()
-                .wrap_err("failed to update alias")?;
-        }
-        Err(no_fun) if alias_doesnt_exist_error(&no_fun) => {
-            client
-                .create_alias()
-                .name(alias)
-                .function_name(name)
-                .function_version(version)
-                .send()
-                .await
-                .into_diagnostic()
-                .wrap_err("failed to create alias")?;
-        }
-        Err(no_fun) => {
-            return Err(no_fun)
-                .into_diagnostic()
-                .wrap_err("failed to fetch alias")
-        }
-    };
-
-    Ok(())
-}
-
-fn function_doesnt_exist_error(err: &SdkError<GetFunctionError>) -> bool {
-    match err {
-        SdkError::ServiceError { err, .. } => err.is_resource_not_found_exception(),
-        _ => false,
-    }
-}
-
-fn function_url_config_doesnt_exist_error(err: &SdkError<GetFunctionUrlConfigError>) -> bool {
-    match err {
-        SdkError::ServiceError { err, .. } => err.is_resource_not_found_exception(),
-        _ => false,
-    }
-}
-
-fn delete_function_url_config_doesnt_exist_error(
-    err: &SdkError<DeleteFunctionUrlConfigError>,
-) -> bool {
-    match err {
-        SdkError::ServiceError { err, .. } => err.is_resource_not_found_exception(),
-        _ => false,
-    }
-}
-
-fn alias_doesnt_exist_error(err: &SdkError<GetAliasError>) -> bool {
-    match err {
-        SdkError::ServiceError { err, .. } => err.is_resource_not_found_exception(),
-        _ => false,
+        Ok(())
     }
 }

--- a/crates/cargo-lambda-remote/Cargo.toml
+++ b/crates/cargo-lambda-remote/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.59.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.10.1"
-aws-sdk-lambda = "0.10.1"
+aws-config = "0.11.0"
+aws-sdk-lambda = "0.11.0"
+aws-types = "0.11.0"
 clap = { version = "3.1.17", features = ["derive"] }

--- a/crates/cargo-lambda-remote/src/lib.rs
+++ b/crates/cargo-lambda-remote/src/lib.rs
@@ -2,7 +2,8 @@ use aws_config::{
     meta::region::RegionProviderChain, profile::ProfileFileCredentialsProvider,
     provider_config::ProviderConfig,
 };
-use aws_sdk_lambda::{Client, Region, RetryConfig};
+use aws_sdk_lambda::RetryConfig;
+use aws_types::{region::Region, SdkConfig};
 use clap::Args;
 
 const DEFAULT_REGION: &str = "us-east-1";
@@ -26,29 +27,31 @@ pub struct RemoteConfig {
     retry_attempts: u32,
 }
 
-/// Initialize an AWS Lambda client.
-/// Uses us-east-1 as the default region if no region is provided.
-pub async fn init_client(config: &RemoteConfig) -> Client {
-    let region_provider = RegionProviderChain::first_try(config.region.clone().map(Region::new))
-        .or_default_provider()
-        .or_else(Region::new(DEFAULT_REGION));
-    let region = region_provider.region().await;
+impl RemoteConfig {
+    pub async fn to_sdk_config(&self) -> SdkConfig {
+        let region_provider = RegionProviderChain::first_try(self.region.clone().map(Region::new))
+            .or_default_provider()
+            .or_else(Region::new(DEFAULT_REGION));
+        let region = region_provider.region().await;
 
-    let mut config_loader = aws_config::from_env()
-        .region(region_provider)
-        .retry_config(RetryConfig::default().with_max_attempts(config.retry_attempts));
+        let mut config_loader = aws_config::from_env()
+            .region(region_provider)
+            .retry_config(RetryConfig::default().with_max_attempts(self.retry_attempts));
 
-    if let Some(profile) = &config.profile {
-        let conf = ProviderConfig::without_region().with_region(region);
-        let creds_provider = ProfileFileCredentialsProvider::builder()
-            .profile_name(profile)
-            .configure(&conf)
-            .build();
-        config_loader = config_loader.credentials_provider(creds_provider);
+        if let Some(profile) = &self.profile {
+            let conf = ProviderConfig::without_region().with_region(region);
+            let creds_provider = ProfileFileCredentialsProvider::builder()
+                .profile_name(profile)
+                .configure(&conf)
+                .build();
+            config_loader = config_loader.credentials_provider(creds_provider);
+        }
+
+        config_loader.load().await
     }
-
-    let config = config_loader.load().await;
-    Client::new(&config)
 }
 
+pub mod aws_sdk_config {
+    pub use aws_types::SdkConfig;
+}
 pub use aws_sdk_lambda;


### PR DESCRIPTION
Adds a new flag to the `build` and `deploy` commands to work with extensions.
Adds a flag to the `deploy` command to print the output in different formats.