### PR TITLE
Remove warning about pypi installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,13 @@ brew install cargo-lambda
 
 ### With PyPI
 
-:warning: coming soon
-
 You can also use PyPI to install cargo-lambda:
 
 ```
 pip install cargo-lambda
 ```
 
-### With cargo-install
+### Building from source
 
 Install cargo-lambda on your host machine with Cargo itself:
 


### PR DESCRIPTION
I've published new packages, and the workflow is working now.