### PR TITLE
Change example download endpoint.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-lambda-invoke"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "cargo-lambda-remote",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-lambda"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "cargo-lambda-build",
  "cargo-lambda-deploy",
@@ -681,12 +681,13 @@ version = "0.8.0"
 dependencies = [
  "cargo-lambda-remote",
  "clap",
- "home",
+ "dirs",
  "miette",
  "reqwest",
  "serde_json",
  "strum",
  "strum_macros",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/cargo-lambda-invoke/Cargo.toml
+++ b/crates/cargo-lambda-invoke/Cargo.toml
@@ -18,9 +18,12 @@ rust-version = "1.59.0"
 [dependencies]
 cargo-lambda-remote = { version = "0.8.0", path = "../cargo-lambda-remote" }
 clap = { version = "3.1.18", features = ["derive"] }
-home = "0.5.3"
+dirs = "4.0.0"
 miette = "4.7.1"
 reqwest = { version = "0.11.10", default-features = false, features = ["rustls-tls"] }
 serde_json = "1.0.81"
 strum = "0.24.0"
 strum_macros = "0.24.0"
+
+[dev-dependencies]
+tokio = { version = "1.18.2", features = ["macros", "test-util"] }

--- a/crates/cargo-lambda-invoke/Cargo.toml
+++ b/crates/cargo-lambda-invoke/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-lambda-invoke"
 description = "Cargo subcommand to work with AWS Lambda"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
Some Windows antiviruses think that if your binary contains
raw.githubusercontent.com inside it, it's a virus.

Signed-off-by: David Calavera <david.calavera@gmail.com>