### PR TITLE
set binary as executable

### DIFF
--- a/crates/cargo-lambda-build/src/lib.rs
+++ b/crates/cargo-lambda-build/src/lib.rs
@@ -282,7 +282,7 @@ fn zip_binary<P: AsRef<Path>>(
 
     zip.start_file(
         file_name.to_str().expect("failed to convert file path"),
-        Default::default(),
+        FileOptions::default().unix_permissions(0o755),
     )
     .into_diagnostic()?;
     zip.write_all(binary_data).into_diagnostic()?;


### PR DESCRIPTION
currently the binary that is written into the zip is written with 0644 permissions, we need to make sure it's set to 0755 so that the environment can execute the binary