### PR TITLE
build: update cargo-zibuild to 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-options"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68dacdf12b405b432ddcb94aa5edef0766daf8cb781f484e56b518305afd45ba"
+checksum = "23ce158e74c4b485a51101125ce308f69a62c13310f4c6e9a082acd862f38995"
 dependencies = [
  "clap",
 ]
@@ -784,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-zigbuild"
-version = "0.8.7"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22c8d27eb36a2ed4e6b6f4b9b7150b7a109677d4848351f473ff78126410df8"
+checksum = "3f82d567aa085050598e94d2326132630715fc97506544eef56eea3c1ff7b28f"
 dependencies = [
  "anyhow",
  "cargo-options",

--- a/crates/cargo-lambda-build/Cargo.toml
+++ b/crates/cargo-lambda-build/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.59.0"
 [dependencies]
 cargo-lambda-interactive = { version = "0.8.0", path = "../cargo-lambda-interactive" }
 cargo-lambda-metadata = { version = "0.8.0", path = "../cargo-lambda-metadata" }
-cargo-zigbuild = "0.8.7"
+cargo-zigbuild = "0.10.1"
 clap = { version = "3.1.18", features = ["derive"] }
 home = "0.5.3"
 miette = "4.7.1"

--- a/crates/cargo-lambda-build/src/lib.rs
+++ b/crates/cargo-lambda-build/src/lib.rs
@@ -130,7 +130,7 @@ impl Build {
 
         let mut cmd = self
             .build
-            .build_command("build")
+            .build_command()
             .map_err(|e| miette::miette!("{}", e))?;
 
         if self.build.release {


### PR DESCRIPTION
Update `cargo-zigbuild` to 0.10.1 in the `cargo-lambda-build` crate.

The change made in `crates/cargo-lambda-build/src/lib.rs:133` is because of the commit `https://github.com/messense/cargo-zigbuild/commit/f9c493deaefc402c348ad85f7d7065d2efeea808` that removed the `subcommand` parameter, for what I saw it does the same thing as `.build_command("build")`.