### PR TITLE
Add flag to disable the Zig linker in Linux.

### DIFF
--- a/crates/cargo-lambda-build/Cargo.toml
+++ b/crates/cargo-lambda-build/Cargo.toml
@@ -30,4 +30,4 @@ strum_macros = "0.24.0"
 zip = { version = "0.6.2", features = ["bzip2", "deflate", "time"] }
 
 [dev-dependencies]
-tokio = { version = "1.18.2", features = ["test-util"] }
+tokio = { version = "1.18.2", features = ["macros", "rt"] }


### PR DESCRIPTION
If you use native libraries, the Zig linker has
issues finding the correctly and compiling functions.

This flag allows to disable Zig on Linux. It also sets the GLIBC version to the one that Amazon Linux 2 uses.

Signed-off-by: David Calavera <david.calavera@gmail.com>