### PR TITLE
Add native installers to the zig install options.

### DIFF
--- a/crates/cargo-lambda-build/Cargo.toml
+++ b/crates/cargo-lambda-build/Cargo.toml
@@ -29,6 +29,7 @@ strum = "0.24.0"
 strum_macros = "0.24.0"
 tracing = { version = "0.1.35", features = ["log"] }
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
+which = "4.2.5"
 zip = { version = "0.6.2", features = ["bzip2", "deflate", "time"] }
 
 [dev-dependencies]

--- a/crates/cargo-lambda-build/src/zig.rs
+++ b/crates/cargo-lambda-build/src/zig.rs
@@ -9,15 +9,17 @@ pub async fn check_installation() -> Result<()> {
         return Ok(());
     }
 
+    let options = install_options();
+
     if !is_stdin_tty() {
         println!("Zig is not installed in your system.\nYou can use any of the following options to install it:");
-        println!("\t* pip3 install ziglang (Python 3 required)");
-        println!("\t* npm install -g @ziglang/cli (NPM required)");
+        for option in &options {
+            println!("\t* {}: `{}`", option, option.usage());
+        }
         println!("\t* Download a recent version from https://ziglang.org/download/ and add it to your PATH");
         return Err(miette::miette!("Install Zig and run cargo-lambda again"));
     }
 
-    let options = vec![InstallOption::Pip3, InstallOption::Npm];
     let choice = choose_option(
         "Zig is not installed in your system.\nHow do you want to install Zig?",
         options,
@@ -28,26 +30,62 @@ pub async fn check_installation() -> Result<()> {
 }
 
 enum InstallOption {
-    Pip3,
+    #[cfg(not(windows))]
+    Brew,
+    #[cfg(windows)]
+    Choco,
+    #[cfg(not(windows))]
     Npm,
+    Pip3,
+    #[cfg(windows)]
+    Scoop,
 }
 
 impl std::fmt::Display for InstallOption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            InstallOption::Pip3 => write!(f, "Install with Pip3 (Python 3)"),
+            #[cfg(not(windows))]
+            InstallOption::Brew => write!(f, "Install with Homebrew"),
+            #[cfg(windows)]
+            InstallOption::Choco => write!(f, "Install with Chocolatey"),
+            #[cfg(not(windows))]
             InstallOption::Npm => write!(f, "Install with NPM"),
+            InstallOption::Pip3 => write!(f, "Install with Pip3 (Python 3)"),
+            #[cfg(windows)]
+            InstallOption::Scoop => write!(f, "Install with Scoop"),
         }
     }
 }
 
 impl InstallOption {
+    fn usage(&self) -> &'static str {
+        match self {
+            #[cfg(not(windows))]
+            InstallOption::Brew => "brew install zig",
+            #[cfg(windows)]
+            InstallOption::Choco => "choco install zig",
+            #[cfg(not(windows))]
+            InstallOption::Npm => "npm install -g @ziglang/cli",
+            InstallOption::Pip3 => "pip3 install ziglang",
+            #[cfg(windows)]
+            InstallOption::Scoop => "scoop install zig",
+        }
+    }
+
     async fn install(self) -> Result<()> {
         let pb = Progress::start("Installing Zig...");
         let result = match self {
-            InstallOption::Pip3 => silent_command("pip3", &["install", "ziglang"]).await,
+            #[cfg(not(windows))]
+            InstallOption::Brew => silent_command("brew", &["install", "zig"]).await,
+            #[cfg(windows)]
+            InstallOption::Choco => silent_command("choco", &["install", "zig"]).await,
+            #[cfg(not(windows))]
             InstallOption::Npm => silent_command("npm", &["install", "-g", "@ziglang/cli"]).await,
+            InstallOption::Pip3 => silent_command("pip3", &["install", "ziglang"]).await,
+            #[cfg(windows)]
+            InstallOption::Scoop => silent_command("scoop", &["install", "zig"]).await,
         };
+
         let finish = if result.is_ok() {
             "Zig installed"
         } else {
@@ -57,4 +95,33 @@ impl InstallOption {
 
         result
     }
+}
+
+fn install_options() -> Vec<InstallOption> {
+    let mut options = Vec::new();
+
+    #[cfg(not(windows))]
+    if which::which("brew").is_ok() {
+        options.push(InstallOption::Brew);
+    }
+
+    #[cfg(windows)]
+    if which::which("choco").is_ok() {
+        options.push(InstallOption::Choco);
+    }
+
+    #[cfg(windows)]
+    if which::which("scoop").is_ok() {
+        options.push(InstallOption::Scoop);
+    }
+
+    if which::which("pip3").is_ok() {
+        options.push(InstallOption::Pip3);
+    }
+
+    #[cfg(not(windows))]
+    if which::which("npm").is_ok() {
+        options.push(InstallOption::Npm);
+    }
+    options
 }


### PR DESCRIPTION
Add Chocolatey and Scoop on Windows.
Add Homebrew for Linux and Mac.

Signed-off-by: David Calavera <david.calavera@gmail.com>