### PR TITLE
Add option to specify which http feature to enable.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "which",
  "zip",
 ]
 
@@ -715,6 +716,8 @@ dependencies = [
  "miette",
  "regex",
  "reqwest",
+ "strum",
+ "strum_macros",
  "tempfile",
  "walkdir",
  "zip",

--- a/crates/cargo-lambda-new/Cargo.toml
+++ b/crates/cargo-lambda-new/Cargo.toml
@@ -23,6 +23,8 @@ liquid = "0.26.0"
 miette = "4.7.1"
 regex = "1.5.5"
 reqwest = { version = "0.11.10", default-features = false, features = ["rustls-tls"] }
+strum = "0.24.0"
+strum_macros = "0.24.0"
 tempfile = "3.3.0"
 walkdir = "2.3.2"
 zip = { version = "0.6.2", features = ["bzip2", "deflate", "time"] }


### PR DESCRIPTION
The next stable version of lambda_http allows you to select specific service endpoints that events come from. That makes functions compile much faster.

Signed-off-by: David Calavera <david.calavera@gmail.com>