### PR TITLE
Force release mode on windows.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "which",
  "zip",
 ]
 

--- a/crates/cargo-lambda-watch/src/trace.rs
+++ b/crates/cargo-lambda-watch/src/trace.rs
@@ -20,7 +20,9 @@ pub(crate) fn init_tracing(print_traces: bool) {
     };
     let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
 
-    let fmt = tracing_subscriber::fmt::layer().without_time();
+    let fmt = tracing_subscriber::fmt::layer()
+        .with_target(false)
+        .without_time();
 
     tracing_subscriber::registry()
         .with(telemetry)


### PR DESCRIPTION
When we try to link with debug mode, the arguments to the linker go over the 32K buffer limit on Windows. To mitigate this, we force release mode on windows.

Fixes #77 

Signed-off-by: David Calavera <david.calavera@gmail.com>