### PR TITLE
conditional check for adding prefixed /

### DIFF
--- a/crates/cargo-lambda-watch/src/trigger_router.rs
+++ b/crates/cargo-lambda-watch/src/trigger_router.rs
@@ -43,7 +43,7 @@ pub(crate) fn routes() -> Router {
 
 async fn furls_handler(
     Extension(cmd_tx): Extension<Sender<InvokeRequest>>,
-    Path((function_name, path)): Path<(String, String)>,
+    Path((function_name, mut path)): Path<(String, String)>,
     req: Request<Body>,
 ) -> Result<Response<Body>, ServerError> {
     let (parts, body) = req.into_parts();
@@ -93,7 +93,12 @@ async fn furls_handler(
         .expect("invalid request id format");
 
     let time = Utc::now();
-    let path = format!("/{}", path);
+
+    if let Some(c) = path.chars().next() {
+        if c != '/' {
+            path = format!("/{}", path);
+        }
+    };
 
     let request_context = ApiGatewayV2httpRequestContext {
         stage: Some("$default".into()),


### PR DESCRIPTION
resolves https://github.com/cargo-lambda/cargo-lambda/issues/200

Adds a check when redirecting routes, some requests will add an additional slash at the front of the route:

```
https://127.0.0.1:9000/lambda-name/my-route
```
Which, if the lambda is doing any internal routing may change the route to:
```
https://127.0.0.1:9000//my-route
```
This checks if there is already a forward slash prefixed before inserting a new one resulting in:
```
https://127.0.0.1:9000/my-route
```