### PR TITLE
Fix installation with PIP

### DIFF
--- a/crates/cargo-lambda-cli/pyproject.toml
+++ b/crates/cargo-lambda-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cargo-lambda"
-dependencies = ["ziglang>=0.9.0"]
+dependencies = ["ziglang>=0.9.1"]
 
 [tool.maturin]
 bindings = "bin"


### PR DESCRIPTION
Move pyproject.toml into the cli crate so Maturin can find it and add all the metadata from it.

Fixes #215 

Signed-off-by: David Calavera <david.calavera@gmail.com>