### PR TITLE
Deploy docs with a given reference.

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,8 +2,12 @@
 name: Deploy documentation
 
 on:
-  push:
-    tags: ["v0.11.0"]
+  workflow_dispatch:
+    inputs:
+      ref:
+        required: true
+        description: 'Reference to build the docs from'
+        type: string
 
 permissions:
   contents: read
@@ -23,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
       - name: Setup Pages
         uses: actions/configure-pages@v1
       - uses: pnpm/action-setup@v2


### PR DESCRIPTION
That way they can be released after the packages are public.

Signed-off-by: David Calavera <david.calavera@gmail.com>