### PR TITLE
Add compatible runtimes for Lambda extensions

### DIFF
--- a/crates/cargo-lambda-build/src/lib.rs
+++ b/crates/cargo-lambda-build/src/lib.rs
@@ -277,7 +277,7 @@ pub struct BinaryArchive {
 }
 
 /// Search for the bootstrap file for a function inside the target directory.
-/// If the binary file exists, it creates the zip archive and extracts its architectury by reading the binary.
+/// If the binary file exists, it creates the zip archive and extracts its architecture by reading the binary.
 pub fn find_binary_archive<P: AsRef<Path>>(
     name: &str,
     base_dir: &Option<P>,

--- a/crates/cargo-lambda-deploy/src/extensions.rs
+++ b/crates/cargo-lambda-deploy/src/extensions.rs
@@ -28,6 +28,7 @@ pub(crate) async fn deploy(
     sdk_config: &SdkConfig,
     binary_data: Vec<u8>,
     architecture: Architecture,
+    compatible_runtime: Vec<Runtime>,
     s3_bucket: &Option<String>,
     progress: &Progress,
 ) -> Result<DeployResult> {
@@ -64,7 +65,7 @@ pub(crate) async fn deploy(
         .publish_layer_version()
         .layer_name(name)
         .compatible_architectures(architecture)
-        .compatible_runtimes(Runtime::Providedal2)
+        .set_compatible_runtimes(Some(compatible_runtime))
         .content(input)
         .send()
         .await

--- a/crates/cargo-lambda-deploy/src/lib.rs
+++ b/crates/cargo-lambda-deploy/src/lib.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 use serde_json::ser::to_string_pretty;
 use std::{fs::read, path::PathBuf, time::Duration};
 use strum_macros::{Display, EnumString};
+use cargo_lambda_remote::aws_sdk_lambda::model::Runtime;
 
 mod extensions;
 mod functions;
@@ -75,6 +76,16 @@ pub struct Deploy {
     #[clap(long)]
     extension: bool,
 
+    /// Comma separated list with compatible runtimes for the Lambda Extension (--compatible_runtimes=provided.al2,nodejs16.x)
+    /// List of allowed runtimes can be found in the AWS documentation: https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
+    #[clap(
+        long,
+        use_value_delimiter = true,
+        value_delimiter = ',',
+        default_value = "provided.al2"
+    )]
+    pub compatible_runtimes: Vec<String>,
+
     /// Format to render the output (text, or json)
     #[clap(long, default_value_t = OutputFormat::Text)]
     output_format: OutputFormat,
@@ -109,6 +120,10 @@ impl Deploy {
 
         let sdk_config = self.remote_config.sdk_config(Some(retry)).await;
         let architecture = Architecture::from(archive.architecture.as_str());
+        let compatible_runtime = self.compatible_runtimes
+            .iter()
+            .map(|runtime| Runtime::from(runtime.as_str()))
+            .collect::<Vec<_>>();
 
         let binary_data = read(&archive.path)
             .into_diagnostic()
@@ -120,6 +135,7 @@ impl Deploy {
                 &sdk_config,
                 binary_data,
                 architecture,
+                compatible_runtime,
                 &self.s3_bucket,
                 &progress,
             )


### PR DESCRIPTION
The goal of this pull request is to add `--compatible-runtimes` flag for the Lambda extensions. As noted in the feature request #272 , extensions run in parallel with Lambda functions. This means we can have Rust based extensions used together with functions developed for other runtimes than `provided.al2`. 

Example usage of the flag:

```
cargo lambda deploy --extension --compatible-runtimes="provided.al2,nodejs16.x"
```

Please note, `--compatible-runtimes` accepts multiple comma separated values. Also, it can be entirely omitted if the only runtime we would want to support is `provided.al2`.