### PR TITLE
Fix: Transform `file_name` to contain only forward slashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,6 +700,7 @@ dependencies = [
  "home",
  "miette",
  "object",
+ "path-slash 0.2.1",
  "rustc_version",
  "sha2",
  "strum",
@@ -871,7 +872,7 @@ dependencies = [
  "clap",
  "dirs",
  "fs-err",
- "path-slash",
+ "path-slash 0.1.4",
  "rustc_version",
  "semver",
  "serde",
@@ -2086,6 +2087,12 @@ name = "path-slash"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cacbb3c4ff353b534a67fb8d7524d00229da4cb1dc8c79f4db96e375ab5b619"
+
+[[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "pbkdf2"

--- a/crates/cargo-lambda-build/Cargo.toml
+++ b/crates/cargo-lambda-build/Cargo.toml
@@ -32,6 +32,7 @@ thiserror.workspace = true
 tracing.workspace = true
 which.workspace = true
 zip.workspace = true
+path-slash = "0.2.1"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/cargo-lambda-build/src/lib.rs
+++ b/crates/cargo-lambda-build/src/lib.rs
@@ -20,6 +20,7 @@ use tracing::{debug, warn};
 use zip::{write::FileOptions, ZipWriter};
 
 pub use cargo_zigbuild::Zig;
+use path_slash::PathExt;
 
 mod error;
 use error::BuildError;
@@ -349,7 +350,7 @@ pub fn zip_binary<BP: AsRef<Path>, DD: AsRef<Path>>(
     };
 
     zip.start_file(
-        file_name.to_str().expect("failed to convert file path"),
+        file_name.to_slash().expect("failed to convert file path"),
         FileOptions::default().unix_permissions(binary_perm),
     )
     .into_diagnostic()?;


### PR DESCRIPTION
This PR attempts to fix the bug reported for #271. 

`zip-rs` requires for the zip archive to contain folders separated with forward slashes (`/`). Since we are using the `Path` module from the standard library, in case we transform a path to a string, this string will contain backslashes (`\`) on Windows.

The current fix attempts to converts these paths to use forward slashes regardless of the operating system.