### PR TITLE
Don't use data from default profile if a profile is provided

### DIFF
--- a/crates/cargo-lambda-remote/Cargo.toml
+++ b/crates/cargo-lambda-remote/Cargo.toml
@@ -18,3 +18,6 @@ aws-config.workspace = true
 aws-sdk-lambda.workspace = true
 aws-types.workspace = true
 clap.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/cargo-lambda-remote/src/lib.rs
+++ b/crates/cargo-lambda-remote/src/lib.rs
@@ -73,3 +73,127 @@ pub mod aws_sdk_config {
     pub use aws_types::SdkConfig;
 }
 pub use aws_sdk_lambda;
+
+#[cfg(test)]
+mod tests {
+    use aws_sdk_lambda::Region;
+    use aws_types::credentials::ProvideCredentials;
+
+    use crate::{RemoteConfig, DEFAULT_REGION};
+
+    fn setup() {
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        std::env::set_var("AWS_CONFIG_FILE", format!("{manifest_dir}/test-data/aws_config"));
+        std::env::set_var("AWS_SHARED_CREDENTIALS_FILE", format!("{manifest_dir}/test-data/aws_credentials"));
+    }
+
+    /// Specify a profile which does not exist
+    /// Expectations:
+    /// - Region is undefined, thus uses the `DEFAULT_REGION` as defined in the crate
+    /// - Credentials are undefined
+    #[tokio::test]
+    async fn undefined_profile() {
+        setup();
+
+        let args = RemoteConfig {
+            profile: Some("durian".to_owned()),
+            region: None,
+            alias: None,
+            retry_attempts: 1,
+        };
+
+        let config = args.sdk_config(None).await;
+        let creds = config.credentials_provider().unwrap().provide_credentials().await;
+
+        assert_eq!(config.region(), Some(&Region::from_static(DEFAULT_REGION)));
+        assert!(creds.is_err());
+    }
+
+    /// Specify a profile which exists in the credentials file but not in the config file
+    /// Expectations:
+    /// - Region is undefined, thus uses the `DEFAULT_REGION` as defined in the crate
+    /// - Credentials are used from the profile
+    #[tokio::test]
+    async fn undefined_profile_with_creds() {
+        setup();
+
+        let args = RemoteConfig {
+            profile: Some("cherry".to_owned()),
+            region: None,
+            alias: None,
+            retry_attempts: 1,
+        };
+
+        let config = args.sdk_config(None).await;
+        let creds = config.credentials_provider().unwrap().provide_credentials().await.unwrap();
+
+        assert_eq!(config.region(), Some(&Region::from_static(DEFAULT_REGION)));
+        assert_eq!(creds.access_key_id(), "CCCCCCCCCCCCCCCCCCCCC");
+    }
+
+    /// Specify a profile which has a region associated to it
+    /// Expectations:
+    /// - Region is used from the profile
+    /// - Credentials are used from the profile
+    #[tokio::test]
+    async fn profile_with_region() {
+        setup();
+
+        let args = RemoteConfig {
+            profile: Some("apple".to_owned()),
+            region: None,
+            alias: None,
+            retry_attempts: 1,
+        };
+
+        let config = args.sdk_config(None).await;
+        let creds = config.credentials_provider().unwrap().provide_credentials().await.unwrap();
+
+        assert_eq!(config.region(), Some(&Region::from_static("ca-central-1")));
+        assert_eq!(creds.access_key_id(), "AAAAAAAAAAAAAAAAAAAA");
+    }
+
+    /// Specify a profile which does not have a region associated to it
+    /// Expectations:
+    /// - Region is undefined, thus uses the `DEFAULT_REGION` as defined in the crate
+    /// - Credentials are used from the profile
+    #[tokio::test]
+    async fn profile_without_region() {
+        setup();
+
+        let args = RemoteConfig {
+            profile: Some("banana".to_owned()),
+            region: None,
+            alias: None,
+            retry_attempts: 1,
+        };
+
+        let config = args.sdk_config(None).await;
+        let creds = config.credentials_provider().unwrap().provide_credentials().await.unwrap();
+
+        assert_eq!(config.region(), Some(&Region::from_static(DEFAULT_REGION)));
+        assert_eq!(creds.access_key_id(), "BBBBBBBBBBBBBBBBBBBB");
+    }
+
+    /// Use the default profile which has a region associated to it
+    /// Expectations:
+    /// - Region is used from the profile
+    /// - Credentials are used from the profile
+    #[tokio::test]
+    async fn default_profile() {
+        setup();
+
+        let args = RemoteConfig {
+            profile: None,
+            region: None,
+            alias: None,
+            retry_attempts: 1,
+        };
+
+        let config = args.sdk_config(None).await;
+        let creds = config.credentials_provider().unwrap().provide_credentials().await.unwrap();
+
+        assert_eq!(config.region(), Some(&Region::from_static("af-south-1")));
+        assert_eq!(creds.access_key_id(), "DDDDDDDDDDDDDDDDDDDD");
+    }
+}

--- a/crates/cargo-lambda-remote/test-data/aws_config
+++ b/crates/cargo-lambda-remote/test-data/aws_config
@@ -1,0 +1,8 @@
+[default]
+region = af-south-1
+
+[profile apple]
+region = ca-central-1
+
+[profile banana]
+output = json

--- a/crates/cargo-lambda-remote/test-data/aws_credentials
+++ b/crates/cargo-lambda-remote/test-data/aws_credentials
@@ -1,0 +1,15 @@
+[default]
+aws_access_key_id = DDDDDDDDDDDDDDDDDDDD
+aws_secret_access_key = dDdDdDdDdDdDdDdDdDdDdDdDdDdDdDdDdDdDdDdD
+
+[apple]
+aws_access_key_id = AAAAAAAAAAAAAAAAAAAA
+aws_secret_access_key = aAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaA
+
+[banana]
+aws_access_key_id = BBBBBBBBBBBBBBBBBBBB
+aws_secret_access_key = bBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbB
+
+[cherry]
+aws_access_key_id = CCCCCCCCCCCCCCCCCCCC
+aws_secret_access_key = cCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcC


### PR DESCRIPTION
Fixes https://github.com/cargo-lambda/cargo-lambda/issues/298 assuming the correct behavior is to have the region not set.