### PR TITLE
Flip ordering in the http options.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,6 +794,7 @@ dependencies = [
  "aws-sdk-lambda",
  "aws-types",
  "clap",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/cargo-lambda-new/src/functions.rs
+++ b/crates/cargo-lambda-new/src/functions.rs
@@ -74,12 +74,12 @@ impl HttpEndpoints {
 
     fn all() -> Vec<HttpEndpoints> {
         vec![
+            HttpEndpoints::Unknown,
             HttpEndpoints::Alb,
             HttpEndpoints::ApigwRest,
             HttpEndpoints::ApigwHttp,
             HttpEndpoints::ApigwWebsockets,
             HttpEndpoints::LambdaUrls,
-            HttpEndpoints::Unknown,
         ]
     }
 }


### PR DESCRIPTION
So the default is all endpoints enabled.

Signed-off-by: David Calavera <david.calavera@gmail.com>