### PR TITLE
Add cors header to watch endpoints

### DIFF
--- a/crates/cargo-lambda-watch/Cargo.toml
+++ b/crates/cargo-lambda-watch/Cargo.toml
@@ -42,6 +42,7 @@ tower-http = { version = "0.3.3", features = [
     "catch-panic",
     "request-id",
     "trace",
+    "cors"
 ] }
 tracing.workspace = true
 tracing-opentelemetry = "0.17.2"

--- a/crates/cargo-lambda-watch/src/lib.rs
+++ b/crates/cargo-lambda-watch/src/lib.rs
@@ -15,9 +15,11 @@ use tokio::time::Duration;
 use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 use tower_http::{
     catch_panic::CatchPanicLayer,
+    cors::CorsLayer,
     request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
     trace::TraceLayer,
 };
+
 use tracing::{info, Subscriber};
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::registry::LookupSpan;
@@ -160,7 +162,8 @@ async fn start_server(
         .layer(Extension(req_cache))
         .layer(Extension(resp_cache))
         .layer(TraceLayer::new_for_http())
-        .layer(CatchPanicLayer::new());
+        .layer(CatchPanicLayer::new())
+        .layer(CorsLayer::permissive());
 
     info!("invoke server listening on {}", addr);
     axum::Server::bind(&addr)


### PR DESCRIPTION
I was using the watch endpoint with [turbo frames](https://turbo.hotwired.dev/handbook/frames) and got an error because of missing cors headers. Since the watch command is only used for development, I see no reason not to have it.