### PR TITLE
Global metadata config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,6 +755,7 @@ dependencies = [
  "cargo-lambda-build",
  "cargo-lambda-deploy",
  "cargo-lambda-invoke",
+ "cargo-lambda-metadata",
  "cargo-lambda-new",
  "cargo-lambda-watch",
  "cargo-test-macro",
@@ -856,6 +857,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
+ "toml",
  "tracing",
 ]
 
@@ -967,7 +969,7 @@ dependencies = [
  "snapbox",
  "tar",
  "termcolor",
- "toml_edit",
+ "toml_edit 0.15.0",
  "url",
  "winapi",
 ]
@@ -2773,6 +2775,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3751,6 +3762,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c68e921cef53841b8925c2abadd27c9b891d9613bdc43d6b823062866df38e8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4252,10 +4272,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.5.0"
+name = "toml"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808b51e57d0ef8f71115d8f3a01e7d3750d01c79cac4b3eda910f4389fdf92fd"
+checksum = "4fb9d890e4dc9298b70f740f615f2e05b9db37dce531f6b24fb77ac993f9f217"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.18.0",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
 dependencies = [
  "serde",
 ]
@@ -4271,6 +4303,19 @@ dependencies = [
  "itertools",
  "kstring",
  "serde",
+ "toml_datetime",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729bfd096e40da9c001f778f5cdecbd2957929a24e10e5883d9392220a751581"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ strum = "0.24.0"
 strum_macros = "0.24.0"
 thiserror = "1.0.31"
 tokio = { version = "1.18.2" }
-tracing = { version = "0.1.35", features = ["log"] }
+tracing = { version = "0.1.37", features = ["log"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 uuid = { version = "1.1.2", features = ["v4"] }
 which = "4.2.5"

--- a/crates/cargo-lambda-cli/Cargo.toml
+++ b/crates/cargo-lambda-cli/Cargo.toml
@@ -20,6 +20,7 @@ description.workspace = true
 cargo-lambda-build.workspace = true
 cargo-lambda-deploy.workspace = true
 cargo-lambda-invoke.workspace = true
+cargo-lambda-metadata.workspace = true
 cargo-lambda-new.workspace = true
 cargo-lambda-watch.workspace = true
 clap = { workspace = true, features = ["suggestions"] }

--- a/crates/cargo-lambda-metadata/Cargo.toml
+++ b/crates/cargo-lambda-metadata/Cargo.toml
@@ -25,4 +25,5 @@ serde_json.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 thiserror.workspace = true
+toml = "0.6.0"
 tracing.workspace = true

--- a/crates/cargo-lambda-watch/src/watcher.rs
+++ b/crates/cargo-lambda-watch/src/watcher.rs
@@ -1,7 +1,7 @@
 use crate::requests::ServerError;
 use cargo_lambda_metadata::cargo::function_environment_metadata;
 use ignore_files::{IgnoreFile, IgnoreFilter};
-use std::{convert::Infallible, path::PathBuf, sync::Arc, time::Duration};
+use std::{collections::HashMap, convert::Infallible, path::PathBuf, sync::Arc, time::Duration};
 use tracing::{debug, error, trace, warn};
 use watchexec::{
     action::{Action, Outcome, PreSpawn},
@@ -23,6 +23,7 @@ pub(crate) struct WatcherConfig {
     pub manifest_path: PathBuf,
     pub ignore_files: Vec<IgnoreFile>,
     pub no_reload: bool,
+    pub env_vars: HashMap<String, String>,
 }
 
 pub(crate) async fn new(cmd: Command, wc: WatcherConfig) -> Result<Arc<Watchexec>, ServerError> {
@@ -146,6 +147,7 @@ async fn runtime(cmd: Command, wc: WatcherConfig) -> Result<RuntimeConfig, Serve
         let runtime_api = wc.runtime_api.clone();
         let manifest_path = wc.manifest_path.clone();
         let bin_name = wc.bin_name.clone();
+        let global_vars = wc.env_vars.clone();
 
         async move {
             trace!("loading watch environment metadata");
@@ -161,6 +163,7 @@ async fn runtime(cmd: Command, wc: WatcherConfig) -> Result<RuntimeConfig, Serve
                 command
                     .env("AWS_LAMBDA_FUNCTION_VERSION", "1")
                     .env("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "4096")
+                    .envs(global_vars)
                     .envs(env)
                     .env("AWS_LAMBDA_RUNTIME_API", &runtime_api)
                     .env("AWS_LAMBDA_FUNCTION_NAME", &name);


### PR DESCRIPTION
Add an option for a global configuration file that all commands can extend from. This configuration should allow all commands to be configured from this file, instead of flags.

Closes #335 

Signed-off-by: David Calavera <david.calavera@gmail.com>