### PR TITLE
Flag --no-start for watch command | manually start and debug function with breakpoints

### DIFF
--- a/crates/cargo-lambda-watch/src/lib.rs
+++ b/crates/cargo-lambda-watch/src/lib.rs
@@ -46,6 +46,10 @@ pub struct Watch {
     #[arg(long)]
     no_reload: bool,
 
+    /// Do not start the function. Useful if you start (and debug) your function in your IDE
+    #[arg(long)]
+    no_start: bool,
+
     #[cfg_attr(
         target_os = "windows",
         arg(short = 'a', long, default_value = "127.0.0.1")
@@ -95,6 +99,7 @@ impl Watch {
             .wrap_err("invalid invoke address")?;
         let addr = SocketAddr::from((ip, self.invoke_port));
         let no_reload = self.no_reload;
+        let no_start = self.no_start;
         let cargo_options = self.cargo_options.clone();
 
         let base = dunce::canonicalize(".").into_diagnostic()?;
@@ -107,6 +112,7 @@ impl Watch {
             base,
             ignore_files,
             no_reload,
+            no_start,
             manifest_path: cargo_options.manifest_path.clone(),
             ..Default::default()
         };

--- a/crates/cargo-lambda-watch/src/scheduler.rs
+++ b/crates/cargo-lambda-watch/src/scheduler.rs
@@ -144,10 +144,12 @@ async fn start_scheduler(
         tokio::select! {
             Some(req) = req_rx.recv() => {
                 if let Some((name, api)) = req_cache.upsert(req).await {
-                    let gc_tx = gc_tx.clone();
-                    let cargo_options = cargo_options.clone();
-                    let watcher_config = watcher_config.clone();
-                    subsys.start("lambda runtime", move |s| start_function(s, name, api, cargo_options, watcher_config, gc_tx));
+                    if !watcher_config.no_start {
+                        let gc_tx = gc_tx.clone();
+                        let cargo_options = cargo_options.clone();
+                        let watcher_config = watcher_config.clone();
+                        subsys.start("lambda runtime", move |s| start_function(s, name, api, cargo_options, watcher_config, gc_tx));
+                    }
                 }
             },
             Some(gc) = gc_rx.recv() => {

--- a/crates/cargo-lambda-watch/src/watcher.rs
+++ b/crates/cargo-lambda-watch/src/watcher.rs
@@ -23,6 +23,7 @@ pub(crate) struct WatcherConfig {
     pub manifest_path: PathBuf,
     pub ignore_files: Vec<IgnoreFile>,
     pub no_reload: bool,
+    pub no_start: bool,
 }
 
 pub(crate) async fn new(cmd: Command, wc: WatcherConfig) -> Result<Arc<Watchexec>, ServerError> {

--- a/docs/commands/watch.md
+++ b/docs/commands/watch.md
@@ -1,6 +1,6 @@
 # cargo lambda watch
 
-The watch subcommand emulates the AWS Lambda control plane API. Run this command at the root of a Rust workspace and cargo-lambda will use cargo-watch to hot compile changes in your Lambda functions. Use flag `--no-reload` to avoid hot compilation.
+The watch subcommand emulates the AWS Lambda control plane API. Run this command at the root of a Rust workspace and cargo-lambda will use cargo-watch to hot compile changes in your Lambda functions. Use flag `--no-reload` to avoid hot compilation. Use flag `--no-start` if you want to start you function manually from your IDE and debug it using breakpoints.
 
 ::: warning
 This command works best with the **[Lambda Runtime version 0.5.1](https://crates.io/crates/lambda_runtime/0.5.1)**. Previous versions of the runtime are likely to crash with serialization errors.


### PR DESCRIPTION
When you want to debug your lambda rust function using GDB or LLDB you can attach your debugger to the running process launched by `cargo lambda watch`. Whenever you change your function and it is restarted, you have to attach your debugger to the new process.
A more convenient way is to launch the function via your IDE in debug mode, where the debugger is attached automatically. Then you can call `cargo lambda watch` with the `--no-reload` flag and kill the process that was started by `cargo lambda watch` during the first function invocation, e.g. with `cargo lambda invoke`.
To prevent `cargo lambda watch` from starting a process that has to be killed, this pull request suggests a flag `--no-start`. This way, we can use `cargo lambda watch` to provide the lambda runtime rest API to the function but we can start the lambda function manually in the IDE.