### PR TITLE
fix cors permissions

### DIFF
--- a/crates/cargo-lambda-watch/src/lib.rs
+++ b/crates/cargo-lambda-watch/src/lib.rs
@@ -1,7 +1,12 @@
-use axum::{extract::Extension, http::header::HeaderName, Router};
+use axum::{
+    extract::Extension,
+    http::{header::HeaderName, HeaderValue},
+    Router,
+};
 use cargo_lambda_invoke::DEFAULT_PACKAGE_FUNCTION;
 use cargo_lambda_metadata::env::EnvOptions;
 use clap::{Args, ValueHint};
+use hyper::Method;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use opentelemetry::{
     global,
@@ -204,7 +209,35 @@ async fn start_server(
         .layer(Extension(resp_cache))
         .layer(TraceLayer::new_for_http())
         .layer(CatchPanicLayer::new())
-        .layer(CorsLayer::permissive());
+        .layer(
+            // This manually allows all possible localhost ports
+            // Access-Control-Allow-Origin wildcard '*' is blocked in browsers
+            CorsLayer::new()
+                .allow_origin(
+                    (0..=65535)
+                        .map(|port| format!("http://localhost:{}", port).parse().unwrap())
+                        .collect::<Vec<HeaderValue>>(),
+                )
+                .allow_credentials(true)
+                .allow_methods(vec![
+                    Method::OPTIONS,
+                    Method::GET,
+                    Method::POST,
+                    Method::PUT,
+                    Method::DELETE,
+                    Method::HEAD,
+                    Method::TRACE,
+                    Method::CONNECT,
+                    Method::PATCH,
+                ])
+                .allow_headers(vec![
+                    "content-type".parse().unwrap(),
+                    "authorization".parse().unwrap(),
+                    "x-amz-date".parse().unwrap(),
+                    "x-api-key".parse().unwrap(),
+                    "x-amz-security-token".parse().unwrap(),
+                ]),
+        );
 
     info!("invoke server listening on {}", addr);
     axum::Server::bind(&addr)


### PR DESCRIPTION
In https://github.com/cargo-lambda/cargo-lambda/pull/311/files a permissive CORS layer was introduced which causes fetches to fail in browsers:

> Access to fetch at 'http://localhost:9000/lambda-url/api/graphql' from origin 'http://localhost:3000' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'.

This PR injects all valid localhost TCP ports and also allows the usage of credentials for local development (note that `allow_methods` and `allow_headers` cannot use the wildcard '*' when allowing credentials)