### PR TITLE
discover ignore files from parent origins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,6 +912,7 @@ dependencies = [
  "miette 4.7.1",
  "opentelemetry",
  "opentelemetry-aws",
+ "project-origins",
  "query_map",
  "reqwest",
  "serde",

--- a/crates/cargo-lambda-watch/Cargo.toml
+++ b/crates/cargo-lambda-watch/Cargo.toml
@@ -28,6 +28,7 @@ dunce.workspace = true
 http-api-problem = { version = "0.51.0", features = ["api-error", "hyper"] }
 hyper = "0.14.18"
 ignore-files = "=1.0.1"
+project-origins = "1.2.0"
 miette.workspace = true
 opentelemetry = "0.17.0"
 opentelemetry-aws = "0.5.0"

--- a/crates/cargo-lambda-watch/src/lib.rs
+++ b/crates/cargo-lambda-watch/src/lib.rs
@@ -10,7 +10,7 @@ use opentelemetry::{
 use opentelemetry_aws::trace::XrayPropagator;
 use std::{
     net::{IpAddr, SocketAddr},
-    path::PathBuf,
+    path::{PathBuf, Path},
     str::FromStr,
 };
 use tokio::time::Duration;
@@ -22,7 +22,7 @@ use tower_http::{
     trace::TraceLayer,
 };
 
-use tracing::{info, Subscriber};
+use tracing::{info, Subscriber, trace};
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::registry::LookupSpan;
 
@@ -112,10 +112,7 @@ impl Watch {
         let cargo_options = self.cargo_options.clone();
 
         let base = dunce::canonicalize(".").into_diagnostic()?;
-
-        let (mut global_ignore, _) = ignore_files::from_environment(Some("CARGO_LAMBDA")).await;
-        let (mut ignore_files, _) = ignore_files::from_origin(&base).await;
-        ignore_files.append(&mut global_ignore);
+        let ignore_files = discover_ignore_files(&base).await;
 
         let env = self.env_options.lambda_environment()?;
 
@@ -157,6 +154,28 @@ impl Watch {
         };
         tracing_opentelemetry::layer().with_tracer(tracer)
     }
+}
+
+/// we discover ignore files from the `CARGO_LAMBDA_IGNORE_FILES` environment variable,
+/// the current directory, and any parent directories that represent project roots
+async fn discover_ignore_files(base: &Path) -> Vec<ignore_files::IgnoreFile> {
+    let mut ignore_files = Vec::new();
+
+    let (mut env_ignore, env_ignore_errs) = ignore_files::from_environment(Some("CARGO_LAMBDA")).await;
+    trace!(ignore_files = ?env_ignore, errors = ?env_ignore_errs, "discovered ignore files from environment variable");
+    ignore_files.append(&mut env_ignore);
+
+    let (mut origin_ignore, origin_ignore_errs) = ignore_files::from_origin(base).await;
+    trace!(ignore_files = ?origin_ignore, errors = ?origin_ignore_errs, "discovered ignore files from origin");
+    ignore_files.append(&mut origin_ignore);
+
+    for parent in project_origins::origins(base).await {
+        let (mut parent_ignore, parent_ignore_errs) = ignore_files::from_origin(&parent).await;
+        trace!(parent = ?parent, ignore_files = ?parent_ignore, errors = ?parent_ignore_errs, "discovered ignore files from parent origin");
+        ignore_files.append(&mut parent_ignore);
+    }
+
+    ignore_files
 }
 
 async fn start_server(


### PR DESCRIPTION
this allows us to ignore files that are declared in a `.gitignore` file in a parent directory.  an example of this is in the [aws-lambda-rust-runtime](https://github.com/awslabs/aws-lambda-rust-runtime) crate, where the root crate's `.gitignore` file ignores all `target/` directories so that crates in the `examples/` directory need not ignore the target themselves.