### PR TITLE
docs: Update sidebar layout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
           make -f ../../Makefile build-release-zip tag=${{ github.ref_name }} target=windows-x64
           make -f ../../Makefile build-release-zip tag=${{ github.ref_name }} target=windows-x86
 
-      - name: Package MacOS files
+      - name: Package macOS files
         working-directory: target/github-release
         run: |
           make -f ../../Makefile build-release-tar tag=${{ github.ref_name }} target=apple-darwin

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -15,8 +15,8 @@ export default {
         nav: nav(),
 
         sidebar: {
-            '/guide/': sidebarGuide(),
-            '/commands/': sidebarCommands()
+            '/guide/': sidebar(),
+            '/commands/': sidebar()
         },
 
         editLink: {
@@ -49,7 +49,7 @@ function nav() {
     ]
 }
 
-function sidebarGuide() {
+function sidebar() {
     return [
         {
             text: 'Introduction',
@@ -62,12 +62,7 @@ function sidebarGuide() {
                 { text: 'Screencasts', link: '/guide/screencasts' },
                 { text: 'Automating deployments', link: '/guide/automating-deployments' }
             ]
-        }
-    ]
-}
-
-function sidebarCommands() {
-    return [
+        },
         {
             text: 'Commands',
             collapsible: true,

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -59,7 +59,8 @@ function sidebarGuide() {
                 { text: 'Installation', link: '/guide/installation' },
                 { text: 'Getting Started', link: '/guide/getting-started' },
                 { text: 'Lambda Extensions', link: '/guide/lambda-extensions' },
-                { text: 'Screencasts', link: '/guide/screencasts' }
+                { text: 'Screencasts', link: '/guide/screencasts' },
+                { text: 'Automating deployments', link: '/guide/automating-deployments' }
             ]
         }
     ]

--- a/docs/guide/automating-deployments.md
+++ b/docs/guide/automating-deployments.md
@@ -1,0 +1,130 @@
+# Automated deployments
+
+This page explains how we can use automate the lambda deployment process, using CI. 
+All we need is credentials to an AWS user with the correct permissions.
+
+To read more about the `cargo lambda deploy` command see the [commands](/commands/deploy) documentation.
+
+## Step 1: Create an AWS service account
+
+First we need a set of user credentials, to be able to authenticate to AWS when deploying.
+Our user needs to be able to create, update, and retrieve lambda functions, and it needs to be 
+able to publish new versions.
+
+Here's how you might define the user, using terraform:
+
+```shell
+resource "aws_iam_user" "lambda-service-user" {
+  name = "lambda-service-user"
+}
+
+resource "aws_iam_access_key" "lambda-service-user" {
+  user = aws_iam_user.lambda-service-user.name
+}
+
+resource "aws_iam_policy" "lambda-service-policy" {
+  name   = "lambda-service-policy"
+  policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "lambda:GetFunction",
+          "lambda:CreateFunction",
+          "lambda:UpdateFunctionCode",
+          "lambda:UpdateFunctionConfiguration",
+          "lambda:PublishVersion",
+          "lambda:TagResource"
+        ]
+        Resource = [
+          "arn:aws:lambda:<region>:<account-id>:function:<function-name>",
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "lambda-service-user-policy-attachment" {
+  user       = aws_iam_user.lambda-service-user.name
+  policy_arn = aws_iam_policy.lambda-service-policy.arn
+}
+
+output "aws_access_key_id" {
+  value = aws_iam_access_key.lambda-service.id
+}
+
+output "aws_secret_access_key" {
+  value     = aws_iam_access_key.lambda-service.secret
+  sensitive = true
+}
+```
+
+When applied, the secret access key can be read with `terraform output -raw aws_secret_access_key`.
+
+If you prefer to do this without the use of terraform, feel free to use another
+tool like it, or just create the user directly in the AWS console.
+
+## Step 2: Add credentials to your repository\'s secret
+
+If you're using Github, go to `github.com/<YOUR-ORG-OR-USERNAME>/<REPO>/settings/secrets/actions`, 
+and add the key and secret we just created:
+
+- `AWS_ACCESS_KEY_ID`, and 
+- `AWS_SECRET_ACCESS_KEY`
+
+Feel free to name the secrets what you like as long as they're named correctly in the workflow below.
+
+## Step 3: Creating the release workflow
+
+Once we have the necessary credentials set up, we can create our workflow.
+Here we'll define a workflow which releases a new version of our lambda when code is pushed to our main branch.
+
+```yaml
+name: release
+
+on:
+  push:
+    branches:
+      - main  # or master
+  
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-build-cache
+
+      - name: Release lambda
+        run: |
+          pip install cargo-lambda
+          cargo lambda build --release
+          cargo lambda deploy <FUNCTION-NAME>
+        env:
+          AWS_DEFAULT_REGION: <YOUR-REGION>
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+```
+
+Assuming you've followed all the steps correctly, this should result in a new lambda being created
+if it's the first time the lambda is deployed this way; otherwise a new version is pushed.
+
+Note that you don't need to use Github actions for this. This is only meant
+as an example that is comprehensive enough to get you started.
+
+If you have suggestion for how this documentation can be improved, please feel free to submit a PR.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -19,7 +19,7 @@ scoop install cargo-lambda/cargo-lambda
 ```
 </template>
 <template v-slot:mac>
-You can use <a href="https://brew.sh/">Homebrew</a> to install Cargo Lambda on MacOS and Linux. Run the following commands on your terminal to add our tap, and install it:
+You can use <a href="https://brew.sh/">Homebrew</a> to install Cargo Lambda on macOS and Linux. Run the following commands on your terminal to add our tap, and install it:
 
 ```sh
 brew tap cargo-lambda/cargo-lambda

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -2,9 +2,9 @@
 
 Cargo Lambda uses [Zig](https://ziglang.org) to link your functions for Linux systems. The installers below also install Zig for you if it's not in your system.
 
-## With Homebrew (MacOS and Linux)
+## With Homebrew (macOS and Linux)
 
-You can use [Homebrew](https://brew.sh/) to install Cargo Lambda on MacOS and Linux. Run the following commands on your terminal to add our tap, and install it:
+You can use [Homebrew](https://brew.sh/) to install Cargo Lambda on macOS and Linux. Run the following commands on your terminal to add our tap, and install it:
 
 ```sh
 brew tap cargo-lambda/cargo-lambda
@@ -61,5 +61,5 @@ cargo install --locked cargo-lambda
 ```
 
 ::: warning
-cargo-install compiles the binary in your system, which usually takes more than 10 minutes. This method doesn't install [Zig](https://ziglang.org) either, which is a requirement if you want to cross compile packages from MacOS or Windows to Lambda Linux environments.
+cargo-install compiles the binary in your system, which usually takes more than 10 minutes. This method doesn't install [Zig](https://ziglang.org) either, which is a requirement if you want to cross compile packages from macOS or Windows to Lambda Linux environments.
 :::

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,9 +18,9 @@ hero:
 
 features:
   - title: Rust functions on AWS Lambda made simple
-    details: Cross compilate your Rust functions for Linux and ARM processors from MacOS, Windows, and Linux. Powered by Zig.
+    details: Cross compile your Rust functions for Linux and ARM processors from macOS, Windows, and Linux. Powered by Zig.
   - title: Native Developer Experience
     details: Run and test your functions locally without Docker, VMs, or any other additional tools.
   - title: From zero to production with one single tool
-    details: Organize your work around common workflows. Cargo Lambda helps you start your projects and take them to production when they are ready.
+    details: Organize your work-around common workflows. Cargo Lambda helps you start your projects and take them to production when they are ready.
 ---


### PR DESCRIPTION
This builds on #386, but I'm not sure how to point at that PR without just creating a PR in my fork exclusively :upside_down_face: 

Bit of a bonus PR, I just wanted to suggest a slight change in the layout of the documentation. Since the `commands` section wasn't immediately obvious it took me a while to find it at first.

This just makes both categories visible in the sidebar at all times. 

![image](https://user-images.githubusercontent.com/25310870/222278227-d11af160-bae2-4936-857e-b282fca3a14b.png)

This might be personal taste, but I thought I would raise the issue in case you agree with it :slightly_smiling_face:  