### PR TITLE
Enable verbose output for cargo metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,7 +859,7 @@ name = "cargo-lambda-metadata"
 version = "0.18.1"
 dependencies = [
  "aws-sdk-lambda",
- "cargo_metadata 0.14.2",
+ "cargo_metadata",
  "clap",
  "miette 4.7.1",
  "remove_dir_all",
@@ -1016,7 +1016,7 @@ checksum = "f7f66533431659d54043e78b4867fe62cad4e9a5c65c8e659d84e5ae19cec5d6"
 dependencies = [
  "anyhow",
  "cargo-options",
- "cargo_metadata 0.15.2",
+ "cargo_metadata",
  "clap",
  "dirs 4.0.0",
  "fs-err",
@@ -1031,22 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982a0cf6a99c350d7246035613882e376d58cebe571785abc5da4f648d53ac0a"
+checksum = "08a1ec454bc3eead8719cb56e15dbbfecdbc14e4b3a3ae4936cc6e31f5fc0d07"
 dependencies = [
  "camino",
  "cargo-platform",

--- a/crates/cargo-lambda-metadata/Cargo.toml
+++ b/crates/cargo-lambda-metadata/Cargo.toml
@@ -18,7 +18,7 @@ description.workspace = true
 # and it will keep the alphabetic ordering for you.
 [dependencies]
 aws-sdk-lambda.workspace = true
-cargo_metadata = "0.14.2"
+cargo_metadata = "0.15.3"
 clap.workspace = true
 miette = "4.7.1"
 remove_dir_all = "0.7.0"

--- a/crates/cargo-lambda-metadata/src/cargo.rs
+++ b/crates/cargo-lambda-metadata/src/cargo.rs
@@ -7,7 +7,7 @@ use std::{
     fmt::Debug,
     path::{Path, PathBuf},
 };
-use tracing::{debug, trace};
+use tracing::{debug, enabled, trace, Level};
 
 use crate::{
     env::lambda_environment,
@@ -203,6 +203,7 @@ pub fn load_metadata<P: AsRef<Path> + Debug>(manifest_path: P) -> Result<CargoMe
     trace!("loading Cargo metadata");
     let mut metadata_cmd = cargo_metadata::MetadataCommand::new();
     metadata_cmd.no_deps();
+    metadata_cmd.verbose(enabled!(target: "cargo_lambda", Level::TRACE));
 
     // try to split manifest path and assign current_dir to enable parsing a project-specific
     // cargo config
@@ -223,9 +224,9 @@ pub fn load_metadata<P: AsRef<Path> + Debug>(manifest_path: P) -> Result<CargoMe
         }
     }
 
+    trace!(metadata = ?metadata_cmd, "loading cargo metadata");
     let meta = metadata_cmd.exec().into_diagnostic()?;
-
-    trace!(metadata = ?meta, "loaded metadata");
+    trace!(metadata = ?meta, "loaded cargo metadata");
     Ok(meta)
 }
 


### PR DESCRIPTION
This should help to investigate issues like #420 in the future.