### PR TITLE
Adding VPC Configuration to lambda deploy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2133,9 +2133,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/crates/cargo-lambda-metadata/src/cargo.rs
+++ b/crates/cargo-lambda-metadata/src/cargo.rs
@@ -103,9 +103,12 @@ pub struct DeployConfig {
     pub layers: Option<Vec<String>>,
     #[serde(default)]
     pub tags: Option<HashMap<String, String>>,
-
     #[serde(skip)]
     pub use_for_update: bool,
+    #[serde(default)]
+    pub subnet_ids: Option<Vec<String>>,
+    #[serde(default)]
+    pub security_group_ids: Option<Vec<String>>,
 }
 
 impl DeployConfig {
@@ -403,6 +406,12 @@ fn merge_deploy_config(base: &DeployConfig, package_deploy: &DeployConfig) -> De
     }
     if package_deploy.layers.is_some() {
         new_config.layers = package_deploy.layers.clone();
+    }
+    if package_deploy.subnet_ids.is_some() {
+        new_config.subnet_ids = package_deploy.subnet_ids.clone();
+    }
+    if package_deploy.security_group_ids.is_some() {
+        new_config.security_group_ids = package_deploy.security_group_ids.clone();
     }
     tracing::debug!(ws_metadata = ?new_config, package_metadata = ?package_deploy, "finished merging deploy metadata");
     new_config


### PR DESCRIPTION
Since there was no option to set the VPC Configuration to the lambda function trough the `cargo lambda deploy`. I went ahead and added this functionality with this pull request.