### PR TITLE
Do not set timeout on update if not specified

### DIFF
--- a/crates/cargo-lambda-deploy/src/functions.rs
+++ b/crates/cargo-lambda-deploy/src/functions.rs
@@ -243,7 +243,7 @@ async fn upsert_function(
             let mut output = None;
             for attempt in 2..5 {
                 let memory = deploy_metadata.memory.clone().map(Into::into);
-                let timeout = deploy_metadata.timeout.clone().into();
+                let timeout = deploy_metadata.timeout.clone().unwrap_or_default().into();
 
                 let result = client
                     .create_function()
@@ -335,10 +335,12 @@ async fn upsert_function(
                     builder = builder.set_memory_size(memory);
                 }
 
-                let timeout: i32 = deploy_metadata.timeout.clone().into();
-                if conf.timeout.unwrap_or_default() != timeout {
-                    update_config = true;
-                    builder = builder.timeout(timeout);
+                if let Some(timeout) = deploy_metadata.timeout {
+                    let timeout: i32 = timeout.clone().into();
+                    if conf.timeout.unwrap_or_default() != timeout {
+                        update_config = true;
+                        builder = builder.timeout(timeout);
+                    }
                 }
 
                 if should_update_layers(&deploy_metadata.layers, &conf) {
@@ -492,7 +494,7 @@ fn merge_configuration(
 
     if let Some(timeout) = &function_config.timeout {
         if !timeout.is_zero() {
-            deploy_metadata.timeout = timeout.clone()
+            deploy_metadata.timeout = Some(timeout.clone())
         }
     }
 

--- a/crates/cargo-lambda-metadata/src/cargo.rs
+++ b/crates/cargo-lambda-metadata/src/cargo.rs
@@ -87,7 +87,7 @@ pub struct DeployConfig {
     #[serde(default)]
     pub memory: Option<Memory>,
     #[serde(default)]
-    pub timeout: Timeout,
+    pub timeout: Option<Timeout>,
     #[serde(default)]
     pub env: HashMap<String, String>,
     #[serde(default)]
@@ -388,8 +388,10 @@ fn merge_deploy_config(base: &DeployConfig, package_deploy: &DeployConfig) -> De
     if package_deploy.memory.is_some() {
         new_config.memory = package_deploy.memory.clone();
     }
-    if !package_deploy.timeout.is_zero() {
-        new_config.timeout = package_deploy.timeout.clone();
+    if let Some(package_timeout) = &package_deploy.timeout {
+        if !package_timeout.is_zero() {
+            new_config.timeout = Some(package_timeout.clone());
+        }
     }
     new_config.env.extend(package_deploy.env.clone());
     if package_deploy.env_file.is_some() && base.env_file.is_none() {
@@ -502,7 +504,7 @@ mod tests {
         vars.insert("VAR1".to_string(), "VAL1".to_string());
 
         assert_eq!(Some(Memory::Mb512), env.memory);
-        assert_eq!(Timeout::new(60), env.timeout);
+        assert_eq!(Some(Timeout::new(60)), env.timeout);
         assert_eq!(Some(Path::new(".env.production")), env.env_file.as_deref());
         assert_eq!(Some(layers.to_vec()), env.layers);
         assert_eq!(Tracing::Active, env.tracing);


### PR DESCRIPTION
As discussed in #437, this changes the behaviour of the setting of timeout when using the `deploy` command.

**Now:**
If you do not explicitly provide a timeout:
- on creation: use default timeout of 30s
- on update: leave timeout untouched (i.e. if you've changed it through other means it will stay that value)

**Previously:**
If you do not explicitly provide a timeout:
- on creation: use default timeout of 30s
- on update: overwrite the timeout to be 30s, regardless of whether it had been changed

If you do provide an explicit timeout it will set the timeout in both cases.

I've tested it locally and it behaves as expected.