### PR TITLE
use very permissive cors

### DIFF
--- a/crates/cargo-lambda-watch/src/lib.rs
+++ b/crates/cargo-lambda-watch/src/lib.rs
@@ -1,12 +1,7 @@
-use axum::{
-    extract::Extension,
-    http::{header::HeaderName, HeaderValue},
-    Router,
-};
+use axum::{extract::Extension, http::header::HeaderName, Router};
 use cargo_lambda_invoke::DEFAULT_PACKAGE_FUNCTION;
 use cargo_lambda_metadata::env::EnvOptions;
 use clap::{Args, ValueHint};
-use hyper::Method;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use opentelemetry::{
     global,
@@ -234,35 +229,7 @@ async fn start_server(
         .layer(Extension(resp_cache))
         .layer(TraceLayer::new_for_http())
         .layer(CatchPanicLayer::new())
-        .layer(
-            // This manually allows all possible localhost ports
-            // Access-Control-Allow-Origin wildcard '*' is blocked in browsers
-            CorsLayer::new()
-                .allow_origin(
-                    (0..=65535)
-                        .map(|port| format!("http://localhost:{}", port).parse().unwrap())
-                        .collect::<Vec<HeaderValue>>(),
-                )
-                .allow_credentials(true)
-                .allow_methods(vec![
-                    Method::OPTIONS,
-                    Method::GET,
-                    Method::POST,
-                    Method::PUT,
-                    Method::DELETE,
-                    Method::HEAD,
-                    Method::TRACE,
-                    Method::CONNECT,
-                    Method::PATCH,
-                ])
-                .allow_headers(vec![
-                    "content-type".parse().unwrap(),
-                    "authorization".parse().unwrap(),
-                    "x-amz-date".parse().unwrap(),
-                    "x-api-key".parse().unwrap(),
-                    "x-amz-security-token".parse().unwrap(),
-                ]),
-        );
+        .layer(CorsLayer::very_permissive());
 
     info!("invoke server listening on {}", addr);
     axum::Server::bind(&addr)


### PR DESCRIPTION
The previous CORS configuration didn't work because I needed some custom headers because of turbo frames. According to the code, this approach is better because `very_permissive()` should allow whatever you throw after it. Otherwise, we should be able to customize the configuration from the CLI, which is a bad idea.

From https://docs.rs/tower-http/latest/src/tower_http/cors/mod.rs.html#1-716
```
    /// A very permissive configuration:
    ///
    /// - **Credentials allowed.**
    /// - The method received in `Access-Control-Request-Method` is sent back
    ///   as an allowed method.
    /// - The origin of the preflight request is sent back as an allowed origin.
    /// - The header names received in `Access-Control-Request-Headers` are sent
    ///   back as allowed headers.
    /// - No headers are currently exposed, but this may change in the future.
    pub fn very_permissive() -> Self {
        Self::new()
            .allow_credentials(true)
            .allow_headers(AllowHeaders::mirror_request())
            .allow_methods(AllowMethods::mirror_request())
            .allow_origin(AllowOrigin::mirror_request())
    }
```