### PR TITLE
Add endpoint_url option

### DIFF
--- a/crates/cargo-lambda-deploy/src/lib.rs
+++ b/crates/cargo-lambda-deploy/src/lib.rs
@@ -98,6 +98,10 @@ pub struct Deploy {
     /// Name of the function or extension to deploy
     #[arg(value_name = "NAME")]
     name: Option<String>,
+
+    /// Custom endpoint URL to target
+    #[arg(long)]
+    endpoint_url: Option<String>,
 }
 
 impl Deploy {
@@ -123,7 +127,10 @@ impl Deploy {
             .with_max_attempts(3)
             .with_initial_backoff(Duration::from_secs(5));
 
-        let sdk_config = self.remote_config.sdk_config(Some(retry)).await;
+        let sdk_config = self
+            .remote_config
+            .sdk_config_custom_endpoint(Some(retry), self.endpoint_url.clone())
+            .await;
         let architecture = Architecture::from(archive.architecture.as_str());
         let compatible_runtimes = self
             .compatible_runtimes


### PR DESCRIPTION
This PR allows for integration with LocalStack (for example) for integration testing. See #439.

[LocalStack](https://localstack.cloud/) is *"A fully functional local cloud stack - Develop and test your cloud and serverless apps offline!"* It implements AWS in a single docker container for local use or integration testing. It listens to network requests on a local port (default 4566) for integration with other services/tools. In order to integrate tools with LocalStack, they need to connect to the LocalStack container (generally `http://localhost:4566`), rather than AWS (generally `https://lambda.amazonaws.com`).

This PR adds a command line option `--endpoint-url` to `cargo lambda deploy` which allows the configuration of the endpoint when talking to "AWS". This allows upload of the lambda function to LocalStack.

## Usage example

```bash
# Start LocalStack
docker run --rm -d -v /var/run/docker.sock:/var/run/docker.sock -p 4566:4566 localstack/localstack

# Build the lambda function
cargo lambda build

# Upload the lambda function to LocalStack
cargo lambda deploy --endpoint-url http://localhost:4566

# Invoke the function
aws --endpoint-url http://localhost:4566 lambda invoke --function-name <function name> --payload '{}' out.json
```

*Disclaimer: I'm a LocalStack employee*