### PR TITLE
Push multi-arch images to the registry using GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     tags: [ 'v*' ]
 
 env:
+  REGISTRY: ghcr.io
   MATURIN_VERSION: 0.13.6
 
 jobs:
@@ -174,3 +175,44 @@ jobs:
           artifacts: target/upload/*
           prerelease: ${{ contains(github.ref_name, '-pre') }}
           generateReleaseNotes: true
+
+  push-registry:
+    name: Push Docker image
+    runs-on: ubuntu-latest
+    needs: release-all
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
+
+      - name: Log in to registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push image
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          context: .
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            CARGO_LAMBDA_VERSION=${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           toolchain: stable
           target: aarch64-apple-darwin
-          default: true
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
@@ -58,7 +57,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          default: true
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
@@ -133,6 +131,8 @@ jobs:
     name: Release all artifacts
     runs-on: ubuntu-latest
     needs: [ release-macos, release-windows, release-linux ]
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG RUST_VERSION=1.66.0
-FROM --platform=$BUILDPLATFORM rust:${RUST_VERSION}
+FROM rust:${RUST_VERSION}
 
 RUN set -eux; \
     rustup toolchain install stable; \


### PR DESCRIPTION
I was having segfaults trying to build a project using Docker with the following setup:
- arm64 machine
- QEMU (`qemu-system-aarch64`, used for Docker)
- Docker image (_amd64_, since it's the default)
- Target of the build: arm64

Switching to `qemu-system-x86_64` fixed my issues, but it would be nice to have everything working on the same architecture.

It doesn't seem like the images are built automatically, so I went ahead with automating that too.