### PR TITLE
Add skip target check option

### DIFF
--- a/crates/cargo-lambda-build/src/compiler/cargo.rs
+++ b/crates/cargo-lambda-build/src/compiler/cargo.rs
@@ -27,7 +27,12 @@ impl Cargo {
 
 #[async_trait::async_trait]
 impl Compiler for Cargo {
-    async fn command(&self, cargo: &Build, _target_arch: &TargetArch) -> Result<Command> {
+    async fn command(
+        &self,
+        cargo: &Build,
+        _target_arch: &TargetArch,
+        _skip_target_check: bool,
+    ) -> Result<Command> {
         tracing::debug!("compiling with Cargo");
 
         let mut cmd = if let Some(subcommand) = &self.compiler.subcommand {

--- a/crates/cargo-lambda-build/src/compiler/cargo_zigbuild.rs
+++ b/crates/cargo-lambda-build/src/compiler/cargo_zigbuild.rs
@@ -9,13 +9,20 @@ pub(crate) struct CargoZigbuild;
 
 #[async_trait::async_trait]
 impl Compiler for CargoZigbuild {
-    async fn command(&self, cargo: &Build, target_arch: &TargetArch) -> Result<Command> {
+    async fn command(
+        &self,
+        cargo: &Build,
+        target_arch: &TargetArch,
+        skip_target_check: bool,
+    ) -> Result<Command> {
         tracing::debug!("compiling with CargoZigbuild");
         crate::zig::check_installation().await?;
 
         // confirm that target component is included in host toolchain, or add
         // it with `rustup` otherwise.
-        crate::toolchain::check_target_component_with_rustc_meta(target_arch).await?;
+        if !skip_target_check {
+            crate::toolchain::check_target_component_with_rustc_meta(target_arch).await?;
+        }
 
         #[allow(unused_mut)]
         let mut zig_build: ZigBuild = cargo.to_owned().into();

--- a/crates/cargo-lambda-build/src/compiler/cross.rs
+++ b/crates/cargo-lambda-build/src/compiler/cross.rs
@@ -8,7 +8,12 @@ pub(crate) struct Cross;
 
 #[async_trait::async_trait]
 impl Compiler for Cross {
-    async fn command(&self, cargo: &Build, _target_arch: &TargetArch) -> Result<Command> {
+    async fn command(
+        &self,
+        cargo: &Build,
+        _target_arch: &TargetArch,
+        _skip_target_check: bool,
+    ) -> Result<Command> {
         tracing::debug!("compiling with Cross");
 
         let cmd = cargo.command();

--- a/crates/cargo-lambda-build/src/compiler/mod.rs
+++ b/crates/cargo-lambda-build/src/compiler/mod.rs
@@ -13,7 +13,12 @@ use cross::Cross;
 
 #[async_trait::async_trait]
 pub(crate) trait Compiler {
-    async fn command(&self, cargo: &Build, target_arch: &TargetArch) -> Result<Command>;
+    async fn command(
+        &self,
+        cargo: &Build,
+        target_arch: &TargetArch,
+        skip_target_check: bool,
+    ) -> Result<Command>;
 
     fn build_profile<'a>(&self, cargo: &'a Build) -> &'a str {
         build_profile(cargo.profile.as_deref(), cargo.release)

--- a/crates/cargo-lambda-build/src/lib.rs
+++ b/crates/cargo-lambda-build/src/lib.rs
@@ -69,6 +69,10 @@ pub struct Build {
     #[arg(long)]
     flatten: Option<String>,
 
+    /// Whether to skip the target check
+    #[arg(long)]
+    skip_target_check: bool,
+
     #[arg(short, long, env = "CARGO_LAMBDA_COMPILER")]
     compiler: Option<CompilerFlag>,
 
@@ -178,7 +182,9 @@ impl Build {
 
         let compiler = new_compiler(compiler_option);
         let profile = compiler.build_profile(&self.build);
-        let cmd = compiler.command(&self.build, &target_arch).await;
+        let cmd = compiler
+            .command(&self.build, &target_arch, self.skip_target_check)
+            .await;
 
         let mut cmd = match cmd {
             Ok(cmd) => cmd,


### PR DESCRIPTION
Add the command line option `--skip-target-check` to skip target checking when running `cargo lambda build`.

Closes #471 