### PR TITLE
Respect CARGO_TARGET_DIR on deploys

### DIFF
--- a/crates/cargo-lambda-deploy/src/lib.rs
+++ b/crates/cargo-lambda-deploy/src/lib.rs
@@ -220,7 +220,12 @@ impl Deploy {
                 };
                 let binary_name = self.binary_name.as_deref().unwrap_or(&name);
 
-                let arc = find_binary_archive(binary_name, &self.lambda_dir, self.extension)?;
+                let arc = find_binary_archive(
+                    binary_name,
+                    &self.manifest_path,
+                    &self.lambda_dir,
+                    self.extension,
+                )?;
                 (name, arc)
             }
         };


### PR DESCRIPTION
If the environment variable is set, we should respect it to pick the target directory.

Part of #467 