### PR TITLE
Fix recursive ignore files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,7 +957,6 @@ dependencies = [
  "miette 4.7.1",
  "opentelemetry",
  "opentelemetry-aws",
- "project-origins",
  "query_map",
  "reqwest",
  "serde",

--- a/crates/cargo-lambda-watch/Cargo.toml
+++ b/crates/cargo-lambda-watch/Cargo.toml
@@ -28,7 +28,6 @@ dunce.workspace = true
 http-api-problem = { version = "0.51.0", features = ["api-error", "hyper"] }
 hyper = "0.14.18"
 ignore-files = "=1.2.0"
-project-origins = "1.2.0"
 miette.workspace = true
 opentelemetry = "0.17.0"
 opentelemetry-aws = "0.5.0"


### PR DESCRIPTION
Search only for Cargo.toml files. Ignore other directories that are not parents of the base.

Fixes #445 