### PR TITLE
clap improvements

### DIFF
--- a/crates/cargo-lambda-metadata/src/env.rs
+++ b/crates/cargo-lambda-metadata/src/env.rs
@@ -15,7 +15,7 @@ pub struct EnvOptions {
 
     /// Command separated list of environment variables (--env-vars KEY=VALUE,OTHER=NEW-VALUE)
     /// This option overrides any values set with the --env-var flag that match the same key.
-    #[arg(long)]
+    #[arg(long, value_delimiter = ',')]
     pub env_vars: Option<Vec<String>>,
 
     /// Read environment variables from a file.

--- a/crates/cargo-lambda-watch/src/lib.rs
+++ b/crates/cargo-lambda-watch/src/lib.rs
@@ -91,11 +91,11 @@ struct CargoOptions {
     manifest_path: PathBuf,
 
     /// Features to pass to `cargo run`, separated by comma
-    #[arg(long)]
+    #[arg(long, short = 'F')]
     features: Option<String>,
 
     /// Enable release mode when the emulator starts
-    #[arg(long)]
+    #[arg(long, short = 'r')]
     release: bool,
 }
 


### PR DESCRIPTION
I noticed that `watch` didn't behave in the same way as `build` when using `-F` and `-r`. This PR fixes both.

Additionally, `--env-vars` doesn't work when using it with `watch`, this PR also addresses that.