### PR TITLE
Allow static linking with Cargo on Linux

### DIFF
--- a/crates/cargo-lambda-build/src/compiler/cargo.rs
+++ b/crates/cargo-lambda-build/src/compiler/cargo.rs
@@ -27,6 +27,7 @@ impl Cargo {
 
 #[async_trait::async_trait]
 impl Compiler for Cargo {
+    #[tracing::instrument(skip(self), target = "cargo_lambda")]
     async fn command(
         &self,
         cargo: &Build,

--- a/crates/cargo-lambda-build/src/compiler/cargo_zigbuild.rs
+++ b/crates/cargo-lambda-build/src/compiler/cargo_zigbuild.rs
@@ -10,6 +10,7 @@ pub(crate) struct CargoZigbuild;
 
 #[async_trait::async_trait]
 impl Compiler for CargoZigbuild {
+    #[tracing::instrument(skip(self), target = "cargo_lambda")]
     async fn command(
         &self,
         cargo: &Build,

--- a/crates/cargo-lambda-build/src/compiler/cross.rs
+++ b/crates/cargo-lambda-build/src/compiler/cross.rs
@@ -9,6 +9,7 @@ pub(crate) struct Cross;
 
 #[async_trait::async_trait]
 impl Compiler for Cross {
+    #[tracing::instrument(skip(self), target = "cargo_lambda")]
     async fn command(
         &self,
         cargo: &Build,

--- a/crates/cargo-lambda-build/src/lib.rs
+++ b/crates/cargo-lambda-build/src/lib.rs
@@ -157,7 +157,7 @@ impl Build {
             // this is not checked
             if target_arch.compatible_host_linker() {
                 target_arch.set_al2_glibc_version();
-            } else {
+            } else if !target_arch.is_static_linking() {
                 return Err(BuildError::InvalidCompilerOption.into());
             }
         }

--- a/crates/cargo-lambda-interactive/src/lib.rs
+++ b/crates/cargo-lambda-interactive/src/lib.rs
@@ -1,7 +1,4 @@
-use inquire::{
-    self,
-    error::{InquireError, InquireResult},
-};
+use inquire::{self, error::InquireResult};
 use is_terminal::IsTerminal;
 use std::fmt::Display;
 


### PR DESCRIPTION
Don't fail when trying to build a static binary on Linux with Cargo as compiler.

Fixes #510 