### PR TITLE
Remove the enforcing of the 2.26 GLIBC version for native compilation.

### DIFF
--- a/crates/cargo-lambda-build/src/compiler/cross.rs
+++ b/crates/cargo-lambda-build/src/compiler/cross.rs
@@ -26,7 +26,7 @@ impl Compiler for Cross {
         cmd.args(args);
 
         if let Some((name, image)) = default_cross_image(
-            &target_arch.rustc_target_without_glibc_version,
+            target_arch.rustc_target_without_glibc_version(),
             cargo_metadata,
         ) {
             cmd.env(name, image);

--- a/crates/cargo-lambda-build/src/toolchain.rs
+++ b/crates/cargo-lambda-build/src/toolchain.rs
@@ -11,7 +11,7 @@ use crate::target_arch::TargetArch;
 /// Check if the target component is installed in the host toolchain, and add
 /// it with `rustup` as needed.
 pub async fn check_target_component_with_rustc_meta(target_arch: &TargetArch) -> Result<()> {
-    let component = &target_arch.rustc_target_without_glibc_version;
+    let component = target_arch.rustc_target_without_glibc_version();
 
     // convert `Channel` enum to a lower-cased string representation
     let toolchain = match target_arch.channel()? {


### PR DESCRIPTION
This is breaking change for people that still use `provided.al2` and it will come accompanied of the first major release.

You can accomplish the same by setting the GLIBC version in the target flag.