### PR TITLE
Release/new non object events

### DIFF
--- a/crates/cargo-lambda-new/src/events.rs
+++ b/crates/cargo-lambda-new/src/events.rs
@@ -1,4 +1,4 @@
-pub(crate) const WELL_KNOWN_EVENTS: [&str; 35] = [
+pub(crate) const WELL_KNOWN_EVENTS: [&str; 36] = [
     "activemq::ActiveMqEvent",
     "autoscaling::AutoScalingEvent",
     "chime_bot::ChimeBotEvent",
@@ -18,6 +18,7 @@ pub(crate) const WELL_KNOWN_EVENTS: [&str; 35] = [
     "cognito::CognitoEvent",
     "config::ConfigEvent",
     "connect::ConnectEvent",
+    "documentdb::DocumentDbEvent",
     "dynamodb::Event",
     "ecr_scan::EcrScanEvent",
     "firehose::KinesisFirehoseEvent",

--- a/crates/cargo-lambda-new/src/events.rs
+++ b/crates/cargo-lambda-new/src/events.rs
@@ -1,4 +1,4 @@
-pub(crate) const WELL_KNOWN_EVENTS: [&str; 36] = [
+pub(crate) const WELL_KNOWN_EVENTS: [&str; 37] = [
     "activemq::ActiveMqEvent",
     "autoscaling::AutoScalingEvent",
     "chime_bot::ChimeBotEvent",
@@ -21,6 +21,7 @@ pub(crate) const WELL_KNOWN_EVENTS: [&str; 36] = [
     "documentdb::DocumentDbEvent",
     "dynamodb::Event",
     "ecr_scan::EcrScanEvent",
+    "eventbridge::EventBridgeEvent",
     "firehose::KinesisFirehoseEvent",
     "iot_1_click::IoTOneClickDeviceEvent",
     "iot_1_click::IoTOneClickEvent",


### PR DESCRIPTION
New well-known events added:

- Eventbridge
- Documentdb

Currently tested with new, watch and invoke functionalities of Cargo Lambda.