### PR TITLE
Update tokio-graceful-shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-take"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +801,26 @@ name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "bytemuck"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
 
 [[package]]
 name = "byteorder"
@@ -4716,19 +4745,19 @@ dependencies = [
 
 [[package]]
 name = "tokio-graceful-shutdown"
-version = "0.13.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30666f313a52f7e87e9f14212d3e33c2ab59b444c405188ffcf8c36a84ca7688"
+checksum = "351221b8de5317abac3a0cb5d79287ed8cca598959f596e2eb4d25637fe03bd3"
 dependencies = [
- "async-recursion",
  "async-trait",
- "futures",
- "log",
+ "atomic",
+ "bytemuck",
  "miette 5.10.0",
  "pin-project-lite",
  "thiserror",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/cargo-lambda-watch/Cargo.toml
+++ b/crates/cargo-lambda-watch/Cargo.toml
@@ -39,7 +39,7 @@ serde_json.workspace = true
 tempfile = "3.3.0"
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "time"] }
-tokio-graceful-shutdown = "0.13.0"
+tokio-graceful-shutdown = "0.14.2"
 tower-http = { version = "0.3.3", features = [
     "catch-panic",
     "request-id",


### PR DESCRIPTION
Hey!

When browsing around, I found your usage of tokio-graceful-shutdown. Specifically the `start_scheduler` function where you spawn one subsystem per action.

Tokio-graceful-shutdown was originally not developed for short-lived subsystems, because the data of every subsystem was kept until program shutdown. So using the crate like this creates quite a memory leak.

Realizing that people might use my crate this way, I completely rewrote the crate so that finished subsystems get cleaned up properly. I published the rewrite as `0.14.0`.

I just thought I'd drop by and update the dependency, to fix this memory leak in your application.
I apologize that I did not anticipate that usecase earlier.

Greetings