### PR TITLE
feat: add 640mb option to memory options

### DIFF
--- a/crates/cargo-lambda-metadata/src/lambda.rs
+++ b/crates/cargo-lambda-metadata/src/lambda.rs
@@ -50,6 +50,8 @@ pub enum Memory {
     Mb256,
     #[strum(to_string = "512")]
     Mb512,
+    #[strum(to_string = "640")]
+    Mb640,
     #[strum(to_string = "1024")]
     Mb1024,
     #[strum(to_string = "1536")]
@@ -80,6 +82,7 @@ impl From<Memory> for i32 {
             Memory::Mb128 => 128,
             Memory::Mb256 => 256,
             Memory::Mb512 => 512,
+            Memory::Mb640 => 640,
             Memory::Mb1024 => 1024,
             Memory::Mb1536 => 1536,
             Memory::Mb2048 => 2048,
@@ -103,6 +106,7 @@ impl TryFrom<i32> for Memory {
             128 => Ok(Memory::Mb128),
             256 => Ok(Memory::Mb256),
             512 => Ok(Memory::Mb512),
+            640 => Ok(Memory::Mb640),
             1024 => Ok(Memory::Mb1024),
             1536 => Ok(Memory::Mb1536),
             2048 => Ok(Memory::Mb2048),


### PR DESCRIPTION
Hi all,

According to this [Article](https://blog.scanner.dev/serverless-speed-rust-vs-go-java-python-in-aws-lambda-functions) and some extra research:

```
You reach maximum S3 read throughput (~90 MB/sec) when you allocate 640MB of memory or more.
Even if your program does not need very much memory, consider allocating 640MB of memory or more to your Lambda function if you need to maximize S3 download throughput. Under the hood, AWS Lambda probably runs your function on a bigger machine with a better network adapter.
```

I did a bunch of tests with multiple values for memory, and actually, 640 MB is the best option for cost and efficiency. Unfortunately, at the moment, there is no option between 512 MB and 1024 MB. I can set 1024 MB, but this is a waste of memory and money, so I would like to have this option available to avoid remembering to set it to 640 MB manually every time I deploy changes to the lambda.

If I miss something, please let me know.
Cheers.