### PR TITLE
Update reqwest feature flag to include root certificates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ dunce = "1.0.3"
 home = "0.5.3"
 miette = { version = "5.10.0" }
 reqwest = { version = "0.11.10", default-features = false, features = [
-    "rustls-tls",
+    "rustls-tls-native-roots",
 ] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"


### PR DESCRIPTION
I was trying to use cargo lambda cli under my corporate network with a self signed certificate.

When running the command
`cargo lambda new PROJECT`

I was getting UnknownIssuer error while trying to download a file, but the download worked fine when using `curl -O` command.

This looks like the same problem solved [https://github.com/rustic-rs/rustic/issues/679](here).