### PR TITLE
Allow to set change the watch request timeouts.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4526,6 +4526,7 @@ dependencies = [
  "http-body",
  "http-range-header",
  "pin-project-lite",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/crates/cargo-lambda-metadata/src/lambda.rs
+++ b/crates/cargo-lambda-metadata/src/lambda.rs
@@ -2,7 +2,7 @@ use serde::{
     de::{Deserializer, Error, Visitor},
     Deserialize,
 };
-use std::{fmt, str::FromStr};
+use std::{fmt, str::FromStr, time::Duration};
 use strum_macros::{Display, EnumString};
 
 use crate::error::MetadataError;
@@ -17,6 +17,10 @@ impl Timeout {
 
     pub fn is_zero(&self) -> bool {
         self.0 == 0
+    }
+
+    pub fn duration(&self) -> Duration {
+        Duration::from_secs(self.0 as u64)
     }
 }
 

--- a/crates/cargo-lambda-watch/Cargo.toml
+++ b/crates/cargo-lambda-watch/Cargo.toml
@@ -37,9 +37,10 @@ tokio = { workspace = true, features = ["sync", "time"] }
 tokio-graceful-shutdown = "0.14.2"
 tower-http = { version = "0.3.3", features = [
     "catch-panic",
+    "cors",
     "request-id",
     "trace",
-    "cors",
+    "timeout",
 ] }
 tracing.workspace = true
 tracing-opentelemetry = "0.17.2"


### PR DESCRIPTION
If the function talks with services that take a long time, this option helps to keep the connection alive until those services reply.