### PR TITLE
fix(clippy): MSRV should be 1.70.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ homepage = "https://github.com/cargo-lambda/cargo-lambda"
 repository = "https://github.com/cargo-lambda/cargo-lambda"
 keywords = ["cargo", "subcommand", "aws", "lambda"]
 description = "Cargo subcommand to work with AWS Lambda"
-rust-version = "1.64.0"
+rust-version = "1.70.0"
 
 [workspace.dependencies]
 aws-config = "1.1.8"

--- a/crates/cargo-lambda-deploy/src/functions.rs
+++ b/crates/cargo-lambda-deploy/src/functions.rs
@@ -491,25 +491,25 @@ fn merge_configuration(
 
     if function_config.role.is_some() {
         deploy_metadata.use_for_update = true;
-        deploy_metadata.iam_role = function_config.role.clone();
+        deploy_metadata.iam_role.clone_from(&function_config.role);
     }
 
     if function_config.layer.is_some() {
         deploy_metadata.use_for_update = true;
-        deploy_metadata.layers = function_config.layer.clone();
+        deploy_metadata.layers.clone_from(&function_config.layer);
     }
 
     if function_config.memory.is_some() {
         deploy_metadata.use_for_update = true;
-        deploy_metadata.memory = function_config.memory.clone();
+        deploy_metadata.memory.clone_from(&function_config.memory);
     }
 
     if function_config.subnet_ids.is_some() {
-        deploy_metadata.subnet_ids = function_config.subnet_ids.clone();
+        deploy_metadata.subnet_ids.clone_from(&function_config.subnet_ids);
     }
 
     if function_config.security_group_ids.is_some() {
-        deploy_metadata.security_group_ids = function_config.security_group_ids.clone();
+        deploy_metadata.security_group_ids.clone_from(&function_config.security_group_ids);
     }
 
     if let Some(timeout) = &function_config.timeout {
@@ -525,7 +525,7 @@ fn merge_configuration(
             deploy_metadata.use_for_update = true;
 
             if config.env_file.is_some() {
-                deploy_metadata.env_file = config.env_file.clone();
+                deploy_metadata.env_file.clone_from(&config.env_file);
             }
 
             let flag_env = config.lambda_environment().into_diagnostic()?;
@@ -541,7 +541,7 @@ fn merge_configuration(
         }
     }
 
-    deploy_metadata.runtime = function_config.runtime.clone();
+    deploy_metadata.runtime.clone_from(&function_config.runtime);
 
     Ok((environment, deploy_metadata))
 }

--- a/crates/cargo-lambda-deploy/src/lib.rs
+++ b/crates/cargo-lambda-deploy/src/lib.rs
@@ -191,7 +191,7 @@ impl Deploy {
 
         let mut tags = self.tags.clone();
         if tags.is_none() {
-            tags = self.tag.clone();
+            tags.clone_from(&self.tag);
         }
 
         let result = if self.dry {

--- a/crates/cargo-lambda-metadata/src/cargo.rs
+++ b/crates/cargo-lambda-metadata/src/cargo.rs
@@ -442,7 +442,7 @@ pub fn function_deploy_metadata<P: AsRef<Path> + Debug>(
     }
 
     if config.s3_bucket.is_none() {
-        config.s3_bucket = s3_bucket.clone();
+        config.s3_bucket.clone_from(s3_bucket);
     }
 
     tracing::debug!(?config, "using deploy configuration from metadata");
@@ -503,7 +503,7 @@ fn merge_deploy_config(base: &mut DeployConfig, package_deploy: &Option<DeployCo
     };
 
     if package_deploy.memory.is_some() {
-        base.memory = package_deploy.memory.clone();
+        base.memory.clone_from(&package_deploy.memory);
     }
     if let Some(package_timeout) = &package_deploy.timeout {
         if !package_timeout.is_zero() {
@@ -512,31 +512,31 @@ fn merge_deploy_config(base: &mut DeployConfig, package_deploy: &Option<DeployCo
     }
     base.env.extend(package_deploy.env.clone());
     if package_deploy.env_file.is_some() && base.env_file.is_none() {
-        base.env_file = package_deploy.env_file.clone();
+        base.env_file.clone_from(&package_deploy.env_file);
     }
     if package_deploy.tracing != Tracing::default() {
         base.tracing = package_deploy.tracing.clone();
     }
     if package_deploy.iam_role.is_some() {
-        base.iam_role = package_deploy.iam_role.clone();
+        base.iam_role.clone_from(&package_deploy.iam_role);
     }
     if package_deploy.layers.is_some() {
-        base.layers = package_deploy.layers.clone();
+        base.layers.clone_from(&package_deploy.layers);
     }
     if package_deploy.subnet_ids.is_some() {
-        base.subnet_ids = package_deploy.subnet_ids.clone();
+        base.subnet_ids.clone_from(&package_deploy.subnet_ids);
     }
     if package_deploy.security_group_ids.is_some() {
-        base.security_group_ids = package_deploy.security_group_ids.clone();
+        base.security_group_ids.clone_from(&package_deploy.security_group_ids);
     }
-    base.runtime = package_deploy.runtime.clone();
+    base.runtime.clone_from(&package_deploy.runtime);
     if let Some(package_include) = &package_deploy.include {
         let mut include = base.include.clone().unwrap_or_default();
         include.extend(package_include.clone());
         base.include = Some(include);
     }
     if package_deploy.s3_bucket.is_some() {
-        base.s3_bucket = package_deploy.s3_bucket.clone();
+        base.s3_bucket.clone_from(&package_deploy.s3_bucket);
     }
     if let Some(package_tags) = &package_deploy.tags {
         let mut tags = base.tags.clone().unwrap_or_default();
@@ -549,13 +549,13 @@ fn merge_deploy_config(base: &mut DeployConfig, package_deploy: &Option<DeployCo
 
 fn merge_build_config(base: &mut BuildConfig, package_build: &BuildConfig) {
     if package_build.compiler != base.compiler {
-        base.compiler = package_build.compiler.clone();
+        base.compiler.clone_from(&package_build.compiler);
     }
     if package_build.target != base.target {
-        base.target = package_build.target.clone();
+        base.target.clone_from(&package_build.target);
     }
     if package_build.include != base.include {
-        base.include = package_build.include.clone();
+        base.include.clone_from(&package_build.include);
     }
     tracing::debug!(ws_metadata = ?base, package_metadata = ?package_build, "finished merging build metadata");
 }
@@ -992,7 +992,7 @@ mod tests {
         panic = "abort"
         lto = true
         "#;
-        let metadata: Metadata = toml::from_str(&data).unwrap();
+        let metadata: Metadata = toml::from_str(data).unwrap();
         let profile = metadata.profile.unwrap().release.unwrap();
         assert!(profile.debug_enabled());
     }

--- a/crates/cargo-lambda-watch/src/scheduler.rs
+++ b/crates/cargo-lambda-watch/src/scheduler.rs
@@ -88,7 +88,7 @@ async fn start_function(
     } else {
         None
     };
-    watcher_config.name = name.clone();
+    watcher_config.name.clone_from(&name);
     watcher_config.runtime_api = runtime_api;
 
     let wx = crate::watcher::new(cmd, watcher_config, ext_cache.clone()).await?;


### PR DESCRIPTION
## Why
Since Rust `1.78.0`, `make clippy` does not pass anymore for the following reasons:

<img width="1316" alt="Capture d’écran 2024-05-06 à 09 56 22" src="https://github.com/cargo-lambda/cargo-lambda/assets/2571084/2ba41629-7ba2-459d-87ec-b94a59f20da3">

<img width="1302" alt="Capture d’écran 2024-05-06 à 09 55 22" src="https://github.com/cargo-lambda/cargo-lambda/assets/2571084/142f5cb4-3691-45ab-b3a9-1c025ed43700">

<img width="1315" alt="Capture d’écran 2024-05-06 à 09 59 44" src="https://github.com/cargo-lambda/cargo-lambda/assets/2571084/3abca3fc-0cff-4c56-adbe-13faa2ee8f64">

<img width="1322" alt="Capture d’écran 2024-05-06 à 09 59 51" src="https://github.com/cargo-lambda/cargo-lambda/assets/2571084/21172885-014b-42ad-9395-eb545f494a3a">

## How
- `cargo clippy --fix`
- update MSRV from `1.64.0` to `1.70.0`