### PR TITLE
Allow debug builds on Windows

### DIFF
--- a/crates/cargo-lambda-build/src/archive.rs
+++ b/crates/cargo-lambda-build/src/archive.rs
@@ -319,7 +319,7 @@ fn binary_permissions(meta: &Metadata) -> u32 {
 }
 
 #[cfg(not(unix))]
-fn binary_permissions(meta: &Metadata) -> u32 {
+fn binary_permissions(_meta: &Metadata) -> u32 {
     0o755
 }
 

--- a/crates/cargo-lambda-build/src/compiler/cargo_zigbuild.rs
+++ b/crates/cargo-lambda-build/src/compiler/cargo_zigbuild.rs
@@ -24,18 +24,7 @@ impl CargoZigbuild {
             crate::toolchain::check_target_component_with_rustc_meta(target_arch).await?;
         }
 
-        #[allow(unused_mut)]
-        let mut zig_build: ZigBuild = cargo.to_owned().into();
-
-        #[cfg(windows)]
-        // To understand why we need this,
-        // see https://github.com/cargo-lambda/cargo-lambda/issues/77
-        if !zig_build.release {
-            tracing::info!("Changing profile to release mode. Cargo-lambda doesn't support building on debug mode on Windows");
-            zig_build.release = true;
-            zig_build.profile = Some("release".to_string());
-        }
-
+        let zig_build: ZigBuild = cargo.to_owned().into();
         zig_build.build_command().map_err(|e| miette::miette!(e))
     }
 }

--- a/crates/cargo-lambda-build/src/compiler/mod.rs
+++ b/crates/cargo-lambda-build/src/compiler/mod.rs
@@ -29,13 +29,6 @@ pub(crate) async fn build_command(
 
 #[allow(unused_variables)]
 pub(crate) fn build_profile<'a>(cargo: &'a Build, compiler: &'a CompilerOptions) -> &'a str {
-    // To understand why we need this,
-    // see https://github.com/cargo-lambda/cargo-lambda/issues/77
-    #[cfg(windows)]
-    if compiler.is_cargo_zigbuild() {
-        return "release";
-    }
-
     match cargo.profile.as_deref() {
         Some("dev" | "test") => "debug",
         Some("release" | "bench") => "release",


### PR DESCRIPTION
Zig fixed the problem with large argument lists in 0.13.0 with https://github.com/ziglang/zig/pull/19850.