### PR TITLE
fix: Allow `--no-default-features` in `cargo lambda watch`

### DIFF
--- a/crates/cargo-lambda-watch/src/lib.rs
+++ b/crates/cargo-lambda-watch/src/lib.rs
@@ -117,6 +117,10 @@ struct CargoOptions {
     /// Change the color options in the `cargo run` command
     #[arg(skip)]
     color: String,
+
+    /// Ignore all default features
+    #[arg(long)]
+    no_default_features: bool,
 }
 
 impl Watch {

--- a/crates/cargo-lambda-watch/src/scheduler.rs
+++ b/crates/cargo-lambda-watch/src/scheduler.rs
@@ -133,6 +133,10 @@ fn cargo_command(
         cargo_options.color.clone(),
     ];
 
+    if cargo_options.no_default_features {
+        args.push("--no-default-features".into());
+    }
+
     if let Some(features) = cargo_options.features.as_deref() {
         args.push("--features".into());
         args.push(features.into());


### PR DESCRIPTION
Fixes #688 