### PR TITLE
fix: expose `--package` in `cargo lambda watch`

### DIFF
--- a/crates/cargo-lambda-watch/src/lib.rs
+++ b/crates/cargo-lambda-watch/src/lib.rs
@@ -121,6 +121,10 @@ struct CargoOptions {
     /// Ignore all default features
     #[arg(long)]
     no_default_features: bool,
+
+    /// Package to build
+    #[arg(long, short)]
+    package: Option<String>,
 }
 
 impl Watch {

--- a/crates/cargo-lambda-watch/src/scheduler.rs
+++ b/crates/cargo-lambda-watch/src/scheduler.rs
@@ -146,6 +146,11 @@ fn cargo_command(
         args.push("--release".into());
     }
 
+    if let Some(package) = &cargo_options.package {
+        args.push("--package".into());
+        args.push(package.into());
+    }
+
     if is_valid_bin_name(name) {
         args.push("--bin".into());
         args.push(name.into());


### PR DESCRIPTION
This way you can run binaries that are in different packages.

Fixes #670 