### PR TITLE
feat: Allow changing include destination.

### DIFF
--- a/crates/cargo-lambda-build/src/lib.rs
+++ b/crates/cargo-lambda-build/src/lib.rs
@@ -90,7 +90,7 @@ pub struct Build {
 
     /// Option to add one or more files and directories to include in the output ZIP file (only works with --output-format=zip).
     #[arg(short, long)]
-    include: Option<Vec<PathBuf>>,
+    include: Option<Vec<String>>,
 
     #[command(flatten)]
     build: CargoBuild,

--- a/crates/cargo-lambda-deploy/src/lib.rs
+++ b/crates/cargo-lambda-deploy/src/lib.rs
@@ -34,7 +34,7 @@ struct DryOutput {
     runtimes: Vec<String>,
     tags: Option<String>,
     bucket: Option<String>,
-    include: Option<Vec<PathBuf>>,
+    include: Option<Vec<String>>,
 }
 
 impl std::fmt::Display for DryOutput {
@@ -54,7 +54,7 @@ impl std::fmt::Display for DryOutput {
         if let Some(paths) = &self.include {
             writeln!(f, "🗃️ extra files included:")?;
             for file in paths {
-                writeln!(f, "- {}", file.display())?;
+                writeln!(f, "- {}", file)?;
             }
         }
 
@@ -147,7 +147,7 @@ pub struct Deploy {
 
     /// Option to add one or more files and directories to include in the zip file to upload.
     #[arg(short, long)]
-    include: Option<Vec<PathBuf>>,
+    include: Option<Vec<String>>,
 
     /// Perform all the operations to locate and package the binary to deploy, but don't do the final deploy.
     #[arg(long, alias = "dry-run")]

--- a/crates/cargo-lambda-metadata/src/cargo.rs
+++ b/crates/cargo-lambda-metadata/src/cargo.rs
@@ -57,7 +57,7 @@ pub struct BuildConfig {
     pub compiler: Option<CompilerOptions>,
     pub target: Option<String>,
     #[serde(default)]
-    pub include: Option<Vec<PathBuf>>,
+    pub include: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
@@ -166,7 +166,7 @@ pub struct DeployConfig {
     #[serde(default = "default_runtime")]
     pub runtime: String,
     #[serde(default)]
-    pub include: Option<Vec<PathBuf>>,
+    pub include: Option<Vec<String>>,
     #[serde(default)]
     pub s3_bucket: Option<String>,
 }
@@ -814,7 +814,7 @@ mod tests {
         let metadata = load_metadata(manifest_path).unwrap();
 
         let env = function_build_metadata(&metadata).unwrap();
-        assert_eq!(Some(vec![PathBuf::from("Cargo.toml")]), env.include);
+        assert_eq!(Some(vec!["Cargo.toml".into()]), env.include);
     }
 
     #[test]

--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -208,6 +208,30 @@ In some situations, you might want to add extra files inside the zip file upload
 cargo lambda deploy --include config
 ```
 
+### Modifying the included paths in the zip file
+
+If you want to include files from a parent directory, not inside your project structure, you'll find the challenge that `--include` will use the same path inside the zip file. For example, `../config/data.json` will be named exactly like that inside the zip file, and it will be extracted in a relative location. If you want to change the name of the file or directory when it's included in the zip file, you can use the special syntax `FINAL_NAME:PATH`.
+
+For example, the following command will include all files inside the relative path `../../config` in the zip file, but the base directory will be called `config`:
+
+```
+cargo lambda deploy --include config:../../config
+```
+
+If we were to inspect the zip file to deploy with `unzip -l`, we'd see a structure like this one:
+
+```
+Archive:  bootstrap.zip
+  Length      Date    Time    Name
+---------  ---------- -----   ----
+        0  2024-09-14 18:25   config/
+        8  2024-09-14 18:22   config/production.json
+        8  2024-09-14 18:22   config/database.json
+  3037216  2024-09-14 18:24   bootstrap
+---------                     -------
+  3037232                     4 files
+```
+
 ## Other options
 
 Use the `--help` flag to see other options to configure the function's deployment.


### PR DESCRIPTION
Use `DESTINATION:SOURCE` to change the destination where files are included in the zip file when you use the option `--include` in the build and deploy commands.

Fixes #685 