### PR TITLE
feat(new): add conditional files and template path rendering

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,9 @@ jobs:
       matrix:
         os:
           - label: MacOS (Intel)
-            runner: macos-12
+            runner: macos-13
           - label: MacOS (ARM)
-            runner: macos-14
+            runner: macos-latest
           - label: Ubuntu Latest
             runner: ubuntu-latest
           - label: Windows Latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
       matrix:
         platform:
           - target: aarch64-apple-darwin
-            os: macos-14
+            os: macos-latest
             label: MacOs (ARM)
           - target: x86_64-apple-darwin
-            os: macos-12
+            os: macos-13
             label: MacOS (Intel)
     steps:
       - uses: actions/checkout@v3

--- a/crates/cargo-lambda-cli/tests/cargo_lambda.rs
+++ b/crates/cargo-lambda-cli/tests/cargo_lambda.rs
@@ -549,4 +549,13 @@ fn test_config_template() {
     assert_eq!(json_data["architecture"], "x86_64");
     assert_eq!(json_data["memory"], "128");
     assert_eq!(json_data["timeout"], "3");
+    assert_eq!(json_data["ci_provider"], ".github");
+    assert_eq!(json_data["github_actions"], "false");
+
+    assert!(project
+        .root()
+        .join(".github")
+        .join("actions")
+        .join("build.yml")
+        .exists());
 }

--- a/docs/commands/new.md
+++ b/docs/commands/new.md
@@ -114,6 +114,18 @@ cargo lambda new \
     new-project
 ```
 
+You can also use Liquid variables in file paths themselves. This allows you to dynamically generate file paths based on template variables:
+
+```sh
+cargo lambda new \
+    --template https://github.com/calavera/custom-template \
+    --render-var ci_provider=.github \
+    new-project
+```
+
+For example, a template containing a file path like `{{ci_provider}}/workflows/build.yml` would be rendered as `.github/workflows/build.yml` with the above command.
+
+
 ### Ignore files
 
 By default, Cargo Lambda will ignore the `.git` directory and the `LICENSE` file in the template repository. If you want to ignore additional files in a new project, you can use the flag `--ignore-file`:
@@ -161,15 +173,19 @@ ignore_files = [
     "README.md"
 ]
 
+# Files to conditionally render based on a promptvariable
+[template.render_conditional_files] 
+".github" = { var = "github_actions", value = true }
+
 # Define custom interactive prompts
-prompts = [
-    { name = "project_description", message = "What is the description of your project?", default = "My Lambda" },
-    { name = "enable_tracing", message = "Would you like to enable tracing?", default = false },
-    { name = "runtime", message = "Which runtime would you like to use?", choices = ["provided.al2023", "provided.al2"], default = "provided.al2023" },
-    { name = "architecture", message = "Which architecture would you like to target?", choices = ["x86_64", "arm64"], default = "x86_64" },
-    { name = "memory", message = "How much memory (in MB) would you like to allocate?", default = "128" },
-    { name = "timeout", message = "What timeout (in seconds) would you like to set?", default = "3" }
-]
+[template.prompts]
+project_description = { message = "What is the description of your project?", default = "My Lambda" }
+enable_tracing = { message = "Would you like to enable tracing?", default = false }
+runtime = { message = "Which runtime would you like to use?", choices = ["provided.al2023", "provided.al2"], default = "provided.al2023" }
+architecture = { message = "Which architecture would you like to target?", choices = ["x86_64", "arm64"], default = "x86_64" }
+memory = { message = "How much memory (in MB) would you like to allocate?", default = "128" }
+timeout = { message = "What timeout (in seconds) would you like to set?", default = "3" }
+github_actions = { message = "Would you like to add GitHub Actions CI/CD support?", default = false }
 ```
 
 ## Configuration Options
@@ -177,8 +193,9 @@ prompts = [
 - `disable_default_prompts`: When set to `true`, disables Cargo Lambda's built-in prompts
 - `render_files`: List of files that should be processed by the Liquid template engine
 - `render_all_files`: When `true`, all files in the template will be processed by Liquid
+- `render_conditional_files`: Table of files that should be conditionally rendered based on a prompt variable
 - `ignore_files`: List of files that should not be copied to the new project
-- `prompts`: Array of interactive prompts to collect user input
+- `prompts`: Table of interactive prompts to collect user input
 
 ### Prompt Configuration
 

--- a/tests/templates/config-template/CargoLambda.toml
+++ b/tests/templates/config-template/CargoLambda.toml
@@ -12,11 +12,15 @@ ignore_files = [
     "README.md"
 ]
 
-prompts = [
-    { name = "project_description", message = "What is the description of your project?", default = "My Lambda" },
-    { name = "enable_tracing", message = "Would you like to enable tracing?", default = false },
-    { name = "runtime", message = "Which runtime would you like to use?", choices = ["provided.al2023", "provided.al2"], default = "provided.al2023" },
-    { name = "architecture", message = "Which architecture would you like to target?", choices = ["x86_64", "arm64"], default = "x86_64" },
-    { name = "memory", message = "How much memory (in MB) would you like to allocate?", default = "128" },
-    { name = "timeout", message = "What timeout (in seconds) would you like to set?", default = "3" }
-]
+[template.render_conditional_files]
+".github" = { var = "github_actions", value = true }
+
+[template.prompts]
+project_description = { message = "What is the description of your project?", default = "My Lambda" }
+enable_tracing = { message = "Would you like to enable tracing?", default = false }
+runtime = { message = "Which runtime would you like to use?", choices = ["provided.al2023", "provided.al2"], default = "provided.al2023" }
+architecture = { message = "Which architecture would you like to target?", choices = ["x86_64", "arm64"], default = "x86_64" }
+memory = { message = "How much memory (in MB) would you like to allocate?", default = "128" }
+timeout = { message = "What timeout (in seconds) would you like to set?", default = "3" }
+github_actions = { message = "Would you like to add GitHub Actions CI/CD support?", default = false }
+ci_provider = { message = "Which CI provider would you like to use?", choices = [".github", "circleci"], default = ".github" }

--- a/tests/templates/config-template/template/render-test.json
+++ b/tests/templates/config-template/template/render-test.json
@@ -4,5 +4,7 @@
     "runtime": "{{ runtime }}",
     "architecture": "{{ architecture }}",
     "memory": "{{ memory }}",
-    "timeout": "{{ timeout }}"
+    "timeout": "{{ timeout }}",
+    "ci_provider": "{{ ci_provider }}",
+    "github_actions": "{{ github_actions }}"
 }


### PR DESCRIPTION
Add two new template features to improve flexibility:

1. Conditional file rendering based on prompt variables, allowing template authors to include/exclude files based on user input during project creation via `render_conditional_files` in CargoLambda.toml

2. Template-based path rendering, enabling dynamic file paths using Liquid variables (e.g., "{{ci_provider}}/workflows/build.yml")

- Add RenderCondition struct to handle conditional file logic
- Add render_path_with_variables function for path templating
- Update template config parsing to support both features
- Add tests for both conditional files and path rendering
- Update documentation with examples of both features