### PR TITLE
bug(new): Allow processing events in logs and telemetry extensions

### DIFF
--- a/crates/cargo-lambda-new/src/extensions.rs
+++ b/crates/cargo-lambda-new/src/extensions.rs
@@ -6,13 +6,13 @@ pub(crate) const DEFAULT_TEMPLATE_URL: &str =
     "https://github.com/cargo-lambda/default-extension-template/archive/refs/heads/main.zip";
 
 #[derive(Args, Clone, Debug, Default)]
-#[group(multiple = false, requires = "extension", id = "extension-opts")]
+#[group(requires = "extension", id = "extension-opts")]
 pub(crate) struct Options {
     /// Whether the extension includes a Logs processor
-    #[arg(long)]
+    #[arg(long, conflicts_with = "telemetry")]
     logs: bool,
     /// Whether the extension includes a Telemetry processor
-    #[arg(long)]
+    #[arg(long, conflicts_with = "logs")]
     telemetry: bool,
     /// Whether the extension includes an Events processor
     #[arg(long)]


### PR DESCRIPTION
It's common to attach an events processor to logs and telemetry extensions.