### PR TITLE
Add support for credentials with a SourceIdentity

### DIFF
--- a/crates/cargo-lambda-deploy/src/roles.rs
+++ b/crates/cargo-lambda-deploy/src/roles.rs
@@ -27,7 +27,7 @@ pub(crate) async fn create(config: &SdkConfig, progress: &Progress) -> Result<St
         "Statement": [
             {
                 "Effect": "Allow",
-                "Action": "sts:AssumeRole",
+                "Action": ["sts:AssumeRole","sts:SetSourceIdentity"],
                 "Principal": {
                     "AWS": identity.arn().expect("missing account arn"),
                     "Service": "lambda.amazonaws.com"
@@ -64,6 +64,7 @@ pub(crate) async fn create(config: &SdkConfig, progress: &Progress) -> Result<St
 
     try_assume_role(&sts_client, role_arn).await?;
 
+    policy["Statement"][0]["Action"] = serde_json::json!("sts:AssumeRole");
     policy["Statement"][0]["Principal"] = serde_json::json!({"Service": "lambda.amazonaws.com"});
     tracing::trace!(policy = ?policy, "updating assume policy");
 

--- a/crates/cargo-lambda-deploy/src/roles.rs
+++ b/crates/cargo-lambda-deploy/src/roles.rs
@@ -123,7 +123,7 @@ async fn try_assume_role(client: &StsClient, role_arn: &str) -> Result<()> {
     }
 
     Err(miette::miette!(
-        "failed to assume new lambda role. Try deploying using the flag `--iam-role {}`",
+        "failed to assume new lambda role.\nTry deploying using the flag `--iam-role {}`",
         role_arn
     ))
 }


### PR DESCRIPTION
Fixes part of: https://github.com/cargo-lambda/cargo-lambda/issues/724

When using `cargo lambda deploy` it creates a lambda execution role using your current credentials and then verifies it can assume it. If the current credentials have a SourceIdentity, it requires `sts:SetSourceIdentity` in the trust policy of the role so that it can propagate the SourceIdentity when it assumes the role.  This change adds that permission and then removes it once the role is successfully tested.  I tested this locally using credentials that had a SourceIdentity and it deployed successfully. I also verified the trust policy was successfully modified to be:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "Service": "lambda.amazonaws.com"
            },
            "Action": "sts:AssumeRole"
        }
    ]
}
```

I was not able to figure out the formatting error mentioned in my issue.