### PR TITLE
chore: Make strict mode by default.

### DIFF
--- a/crates/cargo-lambda-metadata/tests/jail.rs
+++ b/crates/cargo-lambda-metadata/tests/jail.rs
@@ -2,6 +2,8 @@
 // where cargo runs from, and it makes other tests fail randomly because they
 // cannot find the Cargo.toml file for test fixtures.
 
+use std::collections::HashMap;
+
 use figment::Jail;
 
 use cargo_lambda_metadata::{
@@ -11,7 +13,7 @@ use cargo_lambda_metadata::{
 };
 
 #[test]
-fn test_jail() {
+fn test_env() {
     Jail::expect_with(|jail| {
         jail.set_env("CARGO_LAMBDA_BUILD.RELEASE", "true");
         jail.set_env("CARGO_LAMBDA_DEPLOY.MEMORY", "1024");
@@ -36,7 +38,67 @@ fn test_jail() {
         assert_eq!(config.deploy.function_config.memory, Some(Memory::Mb1024));
         assert_eq!(config.deploy.function_config.timeout, Some(60.into()));
 
-        jail.clear_env();
+        Ok(())
+    });
+}
+
+#[test]
+fn test_env_with_context() {
+    Jail::expect_with(|jail| {
+        jail.set_env("CARGO_LAMBDA_DEPLOY.MEMORY", "1024");
+
+        jail.create_file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "test"
+    
+                [[bin]]
+                name = "test"
+                path = "src/main.rs"
+            "#,
+        )?;
+
+        let options = ConfigOptions {
+            context: Some("production".to_string()),
+            ..Default::default()
+        };
+
+        let metadata = load_metadata("Cargo.toml").unwrap();
+        let config = load_config_without_cli_flags(&metadata, &options).unwrap();
+
+        assert_eq!(config.deploy.function_config.memory, Some(Memory::Mb1024));
+
+        Ok(())
+    });
+}
+
+#[test]
+fn test_env_with_arrays() {
+    Jail::expect_with(|jail| {
+        jail.set_env("CARGO_LAMBDA_BUILD.FEATURES", "[lambda, env]");
+        jail.set_env("CARGO_LAMBDA_DEPLOY.ENV", "[FOO=BAR, BAZ=QUX]");
+
+        jail.create_file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "test"
+
+                [[bin]]
+                name = "test"
+                path = "src/main.rs"
+            "#,
+        )?;
+
+        let metadata = load_metadata("Cargo.toml").unwrap();
+        let config = load_config_without_cli_flags(&metadata, &ConfigOptions::default()).unwrap();
+
+        assert_eq!(config.build.cargo_opts.features, vec!["lambda", "env"]);
+
+        let env = config.deploy.environment(&HashMap::new()).unwrap();
+        assert_eq!(env.get("FOO"), Some(&"BAR".to_string()));
+        assert_eq!(env.get("BAZ"), Some(&"QUX".to_string()));
 
         Ok(())
     });

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -18,17 +18,17 @@ Each one of these sources overrides the values of the previous ones. For example
 
 ### Merge array behavior
 
-Some configuration options, like `env`, `include`, and `router`, are arrays. By default, these arrays are merged together instead of overridden. This behavior can be changed by using the `--strict` flag in the CLI. This option is only available through the CLI, and through the `CARGO_LAMBDA_STRICT` environment variable. When this option is enabled, array values from the CLI flags will override the values from the configuration files.
+Some configuration options, like `env`, `include`, and `router`, are arrays. By default, these arrays override the values from the previous sources. However, in some cases, you might want to merge the arrays instead of overriding them. This behavior can be changed by using the `--admerge` flag in the CLI. This option is only available through the CLI, and through the `CARGO_LAMBDA_ADMERGE` environment variable. When this option is enabled, array values from the CLI flags will merge with the values from the configuration files.
 
 ## Environment variables
 
 Environment variables are always loaded first, any configuration files loaded after that, or flags in the CLI will override the values from the environment variables.
 
-Environment variables start with `CARGO_LAMBDA_`, and are always in the format of `CARGO_LAMBDA_<SECTION>.<OPTION>`. The valid sections are `build`, `deploy`, and `watch`. For example, the `memory` option in the `deploy` section would be `CARGO_LAMBDA_DEPLOY.MEMORY`. The `release` option in the `build` section would be `CARGO_LAMBDA_BUILD.RELEASE`.
+Environment variables start with `CARGO_LAMBDA_`, and are always in the format of `CARGO_LAMBDA_<SUBCOMMAND>.<OPTION>`. The valid subcommands are `build`, `deploy`, and `watch`. For example, the `memory` option in the `deploy` section would be `CARGO_LAMBDA_DEPLOY.MEMORY`. The `release` option in the `build` section would be `CARGO_LAMBDA_BUILD.RELEASE`.
 
-:::warning
+:::tip
 
-Environment variables are not recommended for values that represent lists of options, like `features`, `layers`, or `tags`. This is because the values are not split into an array, and the values will just be pass as the first value in the array.
+Environment variables that represent lists of options, like `features`, `layers`, or `tags`, MUST be wrapped in square brackets. For example, `CARGO_LAMBDA_BUILD.FEATURES` must be `CARGO_LAMBDA_BUILD.FEATURES="[lambda, env]"`.
 
 :::
 


### PR DESCRIPTION
This is more predictable because it's what all other options use.