### PR TITLE
fix(deploy): Remove double extra file insertion.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,6 +1255,7 @@ dependencies = [
 name = "cargo-lambda"
 version = "1.6.0"
 dependencies = [
+ "assertables",
  "build-data",
  "cargo-lambda-build",
  "cargo-lambda-deploy",
@@ -1316,6 +1317,7 @@ dependencies = [
 name = "cargo-lambda-deploy"
 version = "1.6.0"
 dependencies = [
+ "assertables",
  "aws-sdk-iam",
  "aws-sdk-s3",
  "aws-sdk-sts",

--- a/crates/cargo-lambda-cli/Cargo.toml
+++ b/crates/cargo-lambda-cli/Cargo.toml
@@ -36,6 +36,7 @@ tracing-subscriber.workspace = true
 build-data = "0.1"
 
 [dev-dependencies]
+assertables.workspace = true
 dunce = "1.0.3"
 serde_json.workspace = true
 snapbox = { version = "0.4.3", features = ["cmd", "debug", "path"] }

--- a/crates/cargo-lambda-deploy/Cargo.toml
+++ b/crates/cargo-lambda-deploy/Cargo.toml
@@ -28,3 +28,6 @@ strum_macros.workspace = true
 tokio = { workspace = true, features = ["time"]}
 tracing.workspace = true
 uuid.workspace = true
+
+[dev-dependencies]
+assertables.workspace = true

--- a/crates/cargo-lambda-deploy/src/extensions.rs
+++ b/crates/cargo-lambda-deploy/src/extensions.rs
@@ -37,10 +37,6 @@ pub(crate) async fn deploy(
 ) -> Result<DeployResult> {
     let lambda_client = LambdaClient::new(sdk_config);
 
-    if let Some(extra_files) = &config.include {
-        binary_archive.add_files(extra_files)?;
-    }
-
     let compatible_runtimes = config
         .compatible_runtimes()
         .iter()

--- a/crates/cargo-lambda-deploy/src/functions.rs
+++ b/crates/cargo-lambda-deploy/src/functions.rs
@@ -124,10 +124,6 @@ async fn upsert_function(
         }
     };
 
-    if let Some(extra_files) = &config.include {
-        binary_archive.add_files(extra_files)?;
-    }
-
     let tracing = config.function_config.tracing.clone().unwrap_or_default();
     let tracing_config = TracingConfig::builder()
         .mode(tracing.to_string().as_str().into())


### PR DESCRIPTION
With the configuration refactor, extra files are added when the zip file is created the first time. With removes the need to opening the zip file and adding the extra files later.

Fixes #755 