### PR TITLE
feat(deploy): Add compilation information to the deploy outputs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,6 +1293,7 @@ dependencies = [
  "cargo-options",
  "cargo-zigbuild",
  "chrono",
+ "chrono-humanize",
  "home",
  "miette 5.10.0",
  "object 0.28.4",
@@ -1617,6 +1618,15 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "chrono-humanize"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799627e6b4d27827a814e837b9d8a504832086081806d45b1afa34dc982b023b"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ cargo_metadata = "0.15.3"
 cargo-options = { version = "0.7.5", features = ["serde"] }
 cargo-zigbuild = "0.19.4"
 clap = { version = "4.4.2", features = ["derive"] }
+chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
 dirs = "4"
 dunce = "1.0.3"
 figment = { version = "0.10.19", features = ["env", "test", "toml"] }

--- a/crates/cargo-lambda-build/Cargo.toml
+++ b/crates/cargo-lambda-build/Cargo.toml
@@ -16,6 +16,8 @@ cargo-lambda-interactive.workspace = true
 cargo-lambda-metadata.workspace = true
 cargo-options.workspace = true
 cargo-zigbuild.workspace = true
+chrono.workspace = true
+chrono-humanize = "0.2.3"
 home.workspace = true
 miette.workspace = true
 object = "0.28.4"
@@ -29,10 +31,9 @@ tempfile.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 tracing.workspace = true
+walkdir = "2.4.0"
 which.workspace = true
 zip.workspace = true
-walkdir = "2.4.0"
-chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
 
 [dev-dependencies]
 rstest = "0.21.0"

--- a/crates/cargo-lambda-build/src/lib.rs
+++ b/crates/cargo-lambda-build/src/lib.rs
@@ -20,7 +20,7 @@ use tracing::{debug, warn};
 pub use cargo_zigbuild::Zig;
 
 mod archive;
-pub use archive::{create_binary_archive, zip_binary, BinaryArchive, BinaryData};
+pub use archive::{create_binary_archive, zip_binary, BinaryArchive, BinaryData, BinaryModifiedAt};
 
 mod compiler;
 use compiler::{build_command, build_profile};

--- a/crates/cargo-lambda-deploy/src/lib.rs
+++ b/crates/cargo-lambda-deploy/src/lib.rs
@@ -65,8 +65,7 @@ pub async fn run(
     let architecture = Architecture::from(archive.architecture.as_str());
 
     let result = if config.dry {
-        let output = dry::DeployOutput::new(config, &name, &archive)?;
-        Ok(DeployResult::Dry(output))
+        dry::DeployOutput::new(config, &name, &archive).map(DeployResult::Dry)
     } else if config.extension {
         extensions::deploy(
             config,
@@ -77,6 +76,7 @@ pub async fn run(
             &progress,
         )
         .await
+        .map(DeployResult::Extension)
     } else {
         functions::deploy(
             config,
@@ -88,6 +88,7 @@ pub async fn run(
             &progress,
         )
         .await
+        .map(DeployResult::Function)
     };
 
     progress.finish_and_clear();


### PR DESCRIPTION
This add information about when the deploy you're uploading to AWS was compiled last. It can help users known when they're deploying an binary that has not been compiled in a while.

Fixes #743 