### PR TITLE
fix(deploy): Update state machine to handle state correctly.

### DIFF
--- a/crates/cargo-lambda-deploy/src/functions.rs
+++ b/crates/cargo-lambda-deploy/src/functions.rs
@@ -254,10 +254,11 @@ async fn upsert_function(
                 wait_for_readiness = true;
             }
 
-            if let Some(status) = conf.last_update_status() {
-                if status == &LastUpdateStatus::InProgress {
-                    wait_for_readiness = true;
-                }
+            if conf
+                .last_update_status()
+                .is_some_and(|s| s == &LastUpdateStatus::InProgress)
+            {
+                wait_for_readiness = true;
             }
 
             if wait_for_readiness {
@@ -312,19 +313,21 @@ async fn upsert_function(
                 }
 
                 if let Some(vpc) = &config.function_config.vpc {
-                    update_config = true;
-                    builder = builder.vpc_config(
-                        LambdaVpcConfig::builder()
-                            .set_security_group_ids(vpc.security_group_ids.clone())
-                            .set_subnet_ids(vpc.subnet_ids.clone())
-                            .ipv6_allowed_for_dual_stack(vpc.ipv6_allowed_for_dual_stack)
-                            .build(),
-                    );
+                    if vpc.should_update() {
+                        update_config = true;
+                        builder = builder.vpc_config(
+                            LambdaVpcConfig::builder()
+                                .set_security_group_ids(vpc.security_group_ids.clone())
+                                .set_subnet_ids(vpc.subnet_ids.clone())
+                                .ipv6_allowed_for_dual_stack(vpc.ipv6_allowed_for_dual_stack)
+                                .build(),
+                        );
+                    }
                 }
             }
 
             if update_config {
-                debug!(config = ?builder, "updating function's configuration");
+                debug!("updating function's configuration");
                 builder
                     .send()
                     .await
@@ -398,13 +401,13 @@ async fn upsert_function(
     ))
 }
 
+/// Wait until the function state has been completely propagated.
 async fn wait_for_ready_state(
     client: &LambdaClient,
     name: &str,
     alias: &Option<String>,
     progress: &Progress,
 ) -> Result<()> {
-    // wait until the function state has been completely propagated
     for attempt in 2..5 {
         let backoff = attempt * attempt;
         progress.set_message(&format!(
@@ -421,27 +424,32 @@ async fn wait_for_ready_state(
             .into_diagnostic()
             .wrap_err("failed to fetch the function configuration")?;
 
-        match &conf.state {
-            Some(state) => match state {
-                State::Active | State::Inactive | State::Failed => break,
-                State::Pending => {}
-                other => return Err(miette::miette!("unexpected function state: {:?}", other)),
-            },
-            None => return Err(miette::miette!("unknown function state")),
-        }
+        debug!(function_state = ?conf.state, last_update_status = ?conf.last_update_status, "function state");
 
-        match &conf.last_update_status {
-            Some(state) => match state {
-                LastUpdateStatus::Failed | LastUpdateStatus::Successful => break,
-                LastUpdateStatus::InProgress => {}
-                other => {
-                    return Err(miette::miette!(
-                        "unexpected last update status: {:?}",
-                        other
-                    ))
-                }
-            },
-            None => return Ok(()),
+        let Some(state) = &conf.state else {
+            return Err(miette::miette!("unknown function state"));
+        };
+
+        match (state, conf.last_update_status) {
+            (State::Pending, _) => {} // wait for the function to be ready
+            (
+                State::Active | State::Inactive | State::Failed,
+                Some(LastUpdateStatus::InProgress),
+            ) => {} // wait for the function to be ready
+
+            (
+                State::Active | State::Inactive | State::Failed,
+                None | Some(LastUpdateStatus::Failed | LastUpdateStatus::Successful),
+            ) => break, // function is ready
+
+            (State::Active | State::Inactive | State::Failed, other) => {
+                return Err(miette::miette!(
+                    "unexpected last update status: {:?}",
+                    other
+                ))
+            }
+
+            (other, _) => return Err(miette::miette!("unexpected function state: {:?}", other)),
         }
 
         if attempt == 5 {

--- a/crates/cargo-lambda-metadata/src/cargo/deploy.rs
+++ b/crates/cargo-lambda-metadata/src/cargo/deploy.rs
@@ -409,6 +409,16 @@ impl VpcConfig {
         )?;
         Ok(())
     }
+
+    pub fn should_update(&self) -> bool {
+        let Ok(val) = serde_json::to_value(self) else {
+            return false;
+        };
+        let Ok(default) = serde_json::to_value(VpcConfig::default()) else {
+            return false;
+        };
+        val != default
+    }
 }
 
 impl Deploy {


### PR DESCRIPTION
- Ignore VPC configuration that doesn't have any changes from the default.
- Handle the different combinations of state and update status correctly.

Fixes #759 