### PR TITLE
feat(deploy): Add a description flag for deployed versions.

### DIFF
--- a/crates/cargo-lambda-metadata/src/cargo/deploy.rs
+++ b/crates/cargo-lambda-metadata/src/cargo/deploy.rs
@@ -171,6 +171,10 @@ impl Deploy {
 
         Ok(Some(builder.set_variables(Some(env)).build()))
     }
+
+    pub fn publish_code_without_description(&self) -> bool {
+        self.function_config.description.is_none()
+    }
 }
 
 impl Serialize for Deploy {
@@ -323,6 +327,11 @@ pub struct FunctionDeployConfig {
     #[arg(long, default_value = DEFAULT_RUNTIME)]
     #[serde(default)]
     pub runtime: Option<String>,
+
+    /// A description for the new function version.
+    #[arg(long)]
+    #[serde(default)]
+    pub description: Option<String>,
 }
 
 fn default_runtime() -> String {
@@ -353,6 +362,7 @@ impl FunctionDeployConfig {
             + self.memory.is_some() as usize
             + self.timeout.is_some() as usize
             + self.runtime.is_some() as usize
+            + self.description.is_some() as usize
             + self.vpc.as_ref().map_or(0, |vpc| vpc.count_fields())
             + self
                 .env_options
@@ -399,6 +409,10 @@ impl FunctionDeployConfig {
             if !layer.is_empty() {
                 state.serialize_field("layer", &layer)?;
             }
+        }
+
+        if let Some(description) = &self.description {
+            state.serialize_field("description", &description)?;
         }
 
         if let Some(vpc) = &self.vpc {

--- a/crates/cargo-lambda-remote/src/lib.rs
+++ b/crates/cargo-lambda-remote/src/lib.rs
@@ -25,7 +25,7 @@ pub struct RemoteConfig {
     pub region: Option<String>,
 
     /// AWS Lambda alias to associate the function to
-    #[arg(short, long)]
+    #[arg(short, long, alias = "qualifier")]
     #[serde(default)]
     pub alias: Option<String>,
 

--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -16,6 +16,16 @@ The following video shows you how to use this subcommand:
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/ICUSfTorBnI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
+## Versioning
+
+By default, Cargo Lambda will create a new version of the function when you deploy it. This allows you to keep old versions of the function alive, and you can roll back to a previous version if you need to. Versions are named with a version number by AWS Lambda, this version number cannot be changed. However, you can provide a description for the new version of the function using the `--description` flag. This description will be used as the description for the new version of the function. It's a good idea to provide a description for the new version of the function, so you can easily identify it when you have multiple versions of the function.
+
+For example, you can use the description to associate the deployment with a specific git commit hash:
+
+```
+cargo lambda deploy --description $(git rev-parse HEAD)
+```
+
 ## Working with multiple packages
 
 By default, Cargo Lambda tries to detect the binary that you built before deploying it. This can be challenging if you're working in a workspace with multiple Rust packages. There are multiple ways to provide the information about the package you want to deploy more explicitly in this subcommand.

--- a/docs/commands/invoke.md
+++ b/docs/commands/invoke.md
@@ -75,6 +75,14 @@ The `--remote` flag allows you to send requests to a remote function deployed on
 cargo lambda invoke --remote --data-example apigw-request http-lambda
 ```
 
+### Versioning
+
+You can invoke different remote versions of the function by providing the version number or alias. Use the flag `--qualifier` to specify this version number or alias. For example, if you want to invoke a previous version of the function, you can use the following command:
+
+```
+cargo lambda invoke --remote --data-example apigw-request --qualifier 1 http-lambda
+```
+
 ## Output format
 
 The `--output-format` flag allows you to change the output formatting between plain text and pretty-printed JSON formatting. By default, all function outputs are printed as text.


### PR DESCRIPTION
Allow to set a description for each deployed version, so you can add additional context to a release.

Fixes #777 