### PR TITLE
chore: Enable LTO and codegen-units.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,3 +91,5 @@ zip = { version = "2.1.0", features = ["bzip2", "chrono", "deflate"] }
 
 [profile.release]
 strip = "symbols"
+codegen-units = 1
+lto = true


### PR DESCRIPTION
Fixes #783 