### PR TITLE
fix(watch): Rename shortcut for watch port.

### DIFF
--- a/crates/cargo-lambda-metadata/src/cargo/watch.rs
+++ b/crates/cargo-lambda-metadata/src/cargo/watch.rs
@@ -50,7 +50,7 @@ pub struct Watch {
     pub invoke_address: String,
 
     /// Address port where users send invoke requests
-    #[arg(short = 'p', long, default_value_t = DEFAULT_INVOKE_PORT)]
+    #[arg(short = 'P', long, default_value_t = DEFAULT_INVOKE_PORT)]
     #[serde(default = "default_invoke_port")]
     pub invoke_port: u16,
 


### PR DESCRIPTION
-p is used by Cargo for the packages flag.

Fixes #791 

This is going to be a breaking change unfortunately. The `-p` flag comes from the `cargo-options` crate and cannot be modified 😢 .