### PR TITLE
fix(deploy): Fix memory value parser.

### DIFF
--- a/crates/cargo-lambda-metadata/src/cargo/deploy.rs
+++ b/crates/cargo-lambda-metadata/src/cargo/deploy.rs
@@ -11,7 +11,7 @@ use crate::{
     cargo::deserialize_vec_or_map,
     env::EnvOptions,
     error::MetadataError,
-    lambda::{Memory, Timeout, Tracing},
+    lambda::{Memory, MemoryValueParser, Timeout, Tracing},
 };
 
 const DEFAULT_MANIFEST_PATH: &str = "Cargo.toml";
@@ -285,8 +285,8 @@ pub struct FunctionDeployConfig {
     #[serde(default)]
     pub disable_function_url: bool,
 
-    /// Memory allocated for the function
-    #[arg(long, alias = "memory-size", value_parser = clap::value_parser!(i32).range(128..=10240))]
+    /// Memory allocated for the function. Value must be between 128 and 10240.
+    #[arg(long, alias = "memory-size", value_parser = MemoryValueParser)]
     #[serde(default)]
     pub memory: Option<Memory>,
 
@@ -627,7 +627,7 @@ mod tests {
             config.deploy.function_config.timeout,
             Some(Timeout::new(120))
         );
-        assert_eq!(config.deploy.function_config.memory, Some(Memory(10240)));
+        assert_eq!(config.deploy.function_config.memory, Some(10240.into()));
 
         let tags = config.deploy.lambda_tags().unwrap();
         assert_eq!(tags.len(), 2);

--- a/crates/cargo-lambda-metadata/src/config.rs
+++ b/crates/cargo-lambda-metadata/src/config.rs
@@ -254,7 +254,7 @@ mod tests {
         );
 
         assert_eq!(config.env.get("FOO"), Some(&"BAR".to_string()));
-        assert_eq!(config.deploy.function_config.memory, Some(Memory(512)));
+        assert_eq!(config.deploy.function_config.memory, Some(512.into()));
         assert_eq!(config.deploy.function_config.timeout, Some(60.into()));
 
         assert_eq!(
@@ -374,7 +374,7 @@ mod tests {
 
         let metadata = load_metadata(manifest).unwrap();
         let config = load_config_without_cli_flags(&metadata, &options).unwrap();
-        assert_eq!(config.deploy.function_config.memory, Some(Memory(1024)));
+        assert_eq!(config.deploy.function_config.memory, Some(1024.into()));
 
         let options = ConfigOptions {
             context: Some("development".to_string()),
@@ -383,7 +383,7 @@ mod tests {
         };
 
         let config = load_config_without_cli_flags(&metadata, &options).unwrap();
-        assert_eq!(config.deploy.function_config.memory, Some(Memory(512)));
+        assert_eq!(config.deploy.function_config.memory, Some(512.into()));
 
         let options = ConfigOptions {
             global: Some(global),
@@ -391,7 +391,7 @@ mod tests {
         };
 
         let config = load_config_without_cli_flags(&metadata, &options).unwrap();
-        assert_eq!(config.deploy.function_config.memory, Some(Memory(256)));
+        assert_eq!(config.deploy.function_config.memory, Some(256.into()));
     }
 
     #[test]
@@ -406,7 +406,7 @@ mod tests {
         };
 
         let mut deploy = Deploy::default();
-        deploy.function_config.memory = Some(Memory(2048));
+        deploy.function_config.memory = Some(2048.into());
 
         let args_config = Config {
             deploy,
@@ -415,6 +415,6 @@ mod tests {
 
         let metadata = load_metadata(manifest).unwrap();
         let config = load_config(&args_config, &metadata, &options).unwrap();
-        assert_eq!(config.deploy.function_config.memory, Some(Memory(2048)));
+        assert_eq!(config.deploy.function_config.memory, Some(2048.into()));
     }
 }

--- a/crates/cargo-lambda-metadata/src/error.rs
+++ b/crates/cargo-lambda-metadata/src/error.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 pub enum MetadataError {
     #[error("invalid memory value `{0}`")]
     #[diagnostic()]
-    InvalidMemory(i32),
+    InvalidMemory(String),
     #[error("invalid lambda metadata in Cargo.toml file: {0}")]
     #[diagnostic()]
     InvalidCargoMetadata(#[from] serde_json::Error),

--- a/crates/cargo-lambda-metadata/tests/jail.rs
+++ b/crates/cargo-lambda-metadata/tests/jail.rs
@@ -33,7 +33,7 @@ fn test_env() {
         let config = load_config_without_cli_flags(&metadata, &ConfigOptions::default()).unwrap();
 
         assert!(config.build.cargo_opts.release);
-        assert_eq!(config.deploy.function_config.memory, Some(Memory(1024)));
+        assert_eq!(config.deploy.function_config.memory, Some(1024.into()));
         assert_eq!(config.deploy.function_config.timeout, Some(60.into()));
 
         Ok(())
@@ -65,7 +65,7 @@ fn test_env_with_context() {
         let metadata = load_metadata("Cargo.toml").unwrap();
         let config = load_config_without_cli_flags(&metadata, &options).unwrap();
 
-        assert_eq!(config.deploy.function_config.memory, Some(Memory(1024)));
+        assert_eq!(config.deploy.function_config.memory, Some(1024.into()));
 
         Ok(())
     });


### PR DESCRIPTION
Use a custom parser because clap cannot downcast the Memory struct into i32.

Fixes #810 