### PR TITLE
Fix issue described in #815

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "1.7.2"
+version = "1.7.1"
 authors = ["David Calavera"]
 edition = "2024"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "1.7.1"
+version = "1.7.2"
 authors = ["David Calavera"]
 edition = "2024"
 license = "MIT"

--- a/crates/cargo-lambda-watch/src/lib.rs
+++ b/crates/cargo-lambda-watch/src/lib.rs
@@ -185,6 +185,7 @@ fn build_runtime_state(
         runtime_addr,
         proxy_addr,
         manifest_path.to_path_buf(),
+        config.only_lambda_apis,
         binary_packages,
         config.router.clone(),
     ))

--- a/crates/cargo-lambda-watch/src/state.rs
+++ b/crates/cargo-lambda-watch/src/state.rs
@@ -22,6 +22,7 @@ pub(crate) struct RuntimeState {
     proxy_addr: Option<SocketAddr>,
     runtime_url: String,
     manifest_path: PathBuf,
+    only_lambda_apis: bool,
     pub initial_functions: HashSet<String>,
     pub function_router: Option<FunctionRouter>,
     pub req_cache: RequestCache,
@@ -36,6 +37,7 @@ impl RuntimeState {
         runtime_addr: SocketAddr,
         proxy_addr: Option<SocketAddr>,
         manifest_path: PathBuf,
+        only_lambda_apis: bool,
         initial_functions: HashSet<String>,
         function_router: Option<FunctionRouter>,
     ) -> RuntimeState {
@@ -43,6 +45,7 @@ impl RuntimeState {
             runtime_addr,
             proxy_addr,
             manifest_path,
+            only_lambda_apis,
             initial_functions,
             function_router,
             runtime_url: format!("http://{runtime_addr}{RUNTIME_EMULATOR_PATH}"),
@@ -61,7 +64,7 @@ impl RuntimeState {
     }
 
     pub(crate) fn is_default_function_enabled(&self) -> bool {
-        self.initial_functions.len() == 1
+        self.initial_functions.len() == 1 || self.only_lambda_apis
     }
 
     pub(crate) fn is_function_available(&self, name: &str) -> Result<(), HashSet<String>> {

--- a/crates/cargo-lambda-watch/src/trigger_router.rs
+++ b/crates/cargo-lambda-watch/src/trigger_router.rs
@@ -483,6 +483,7 @@ mod test {
             SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             None,
             PathBuf::new(),
+            false,
             HashSet::new(),
             None,
         ));
@@ -531,6 +532,7 @@ mod test {
             SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             None,
             PathBuf::new(),
+            false,
             HashSet::new(),
             Some(new_router),
         ));
@@ -554,6 +556,7 @@ mod test {
             SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             None,
             PathBuf::new(),
+            false,
             HashSet::new(),
             Some(new_router),
         ));
@@ -582,6 +585,7 @@ mod test {
             SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             None,
             PathBuf::new(),
+            false,
             HashSet::new(),
             config.watch.router,
         ));


### PR DESCRIPTION
#815 

Add `only-lambda-apis` flag to `RuntimeState` and to `is_default_function_enabled` assessment

This allows the default Lambda function functionality to work for `--only-lambda-apis`