### PR TITLE
fix(deploy): Fix the serializer for remote and vpc configurations.

### DIFF
--- a/crates/cargo-lambda-deploy/src/lib.rs
+++ b/crates/cargo-lambda-deploy/src/lib.rs
@@ -63,7 +63,7 @@ pub async fn run(config: &Deploy, metadata: &CargoMetadata) -> Result<()> {
     let sdk_config = remote_config.sdk_config(Some(retry)).await;
 
     let result = if config.dry {
-        dry::DeployOutput::new(config, &name, &archive).map(DeployResult::Dry)
+        dry::DeployOutput::new(config, &name, &sdk_config, &archive).map(DeployResult::Dry)
     } else if config.extension {
         extensions::deploy(config, &name, &sdk_config, &archive, &progress)
             .await

--- a/crates/cargo-lambda-remote/src/lib.rs
+++ b/crates/cargo-lambda-remote/src/lib.rs
@@ -10,7 +10,7 @@ use clap::Args;
 use serde::{Deserialize, Serialize, ser::SerializeStruct};
 pub mod tls;
 
-const DEFAULT_REGION: &str = "us-east-1";
+pub const DEFAULT_REGION: &str = "us-east-1";
 
 #[derive(Args, Clone, Debug, Default, Deserialize, Serialize)]
 pub struct RemoteConfig {


### PR DESCRIPTION
Change them to be inside their own fields, since they're not flattened in the Serde structs.

Fixes #839 