### PR TITLE
fix(watch): Correct logic to ignore files.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ on:
 
 env:
   RUST_BACKTRACE: full
-  SCCACHE_GHA_ENABLED: "true"
+  SCCACHE_GHA_ENABLED: "false"
   RUSTC_WRAPPER: "sccache"
   CARGO_INCREMENTAL: 0
 

--- a/crates/cargo-lambda-watch/src/lib.rs
+++ b/crates/cargo-lambda-watch/src/lib.rs
@@ -6,6 +6,7 @@ use cargo_lambda_metadata::{
         CargoMetadata, CargoPackage, filter_binary_targets_from_metadata, kind_bin_filter,
         selected_bin_filter, watch::Watch,
     },
+    env::SystemEnvExtractor,
     lambda::Timeout,
 };
 use cargo_lambda_remote::tls::TlsOptions;
@@ -83,7 +84,7 @@ pub async fn run(
     }
 
     let base = dunce::canonicalize(".").into_diagnostic()?;
-    let ignore_files = watcher::ignore::discover_files(&base).await;
+    let ignore_files = watcher::ignore::discover_files(&base, SystemEnvExtractor).await;
 
     let env = config.lambda_environment(base_env).into_diagnostic()?;
 

--- a/docs/commands/watch.md
+++ b/docs/commands/watch.md
@@ -340,3 +340,34 @@ This configuration is applied to a function in a package. It will be merged with
 [package.metadata.lambda.watch.router]
 "/products" = "handle-products"
 ```
+
+## Ignore files from hot reloading
+
+Cargo Lambda supports ignore files and directories to avoid hot reloading when certain files are modified. This is useful to avoid unnecessary recompilations when the files are not relevant to the function.
+
+The ignore files are discovered from the following sources:
+
+- Git ignore rules (`.gitignore`)
+- Files in the system using the keywords `CARGO_LAMBDA` and `cargo-lambda`:
+  - `$HOME/.cargo-lambda/ignore`
+  - `$XDG_CONFIG_HOME/cargo-lambda/ignore`
+  - `$APPDATA/cargo-lambda/ignore`
+  - `$USERPROFILE/.cargo-lambda/ignore`
+
+  - `$HOME/.CARGO_LAMBDA/ignore`
+  - `$XDG_CONFIG_HOME/CARGO_LAMBDA/ignore`
+  - `$APPDATA/CARGO_LAMBDA/ignore`
+  - `$USERPROFILE/.CARGO_LAMBDA/ignore`
+- A file named `.cargolambdaignore` in the root of the project.
+- A file specified in the `CARGO_LAMBDA_IGNORE_FILE` environment variable.
+
+The ignore files are merged together and used to create glob patterns that are used to match the files that will be ignored.
+
+The syntax of the ignore files is the same as the one used by [Git](https://git-scm.com/docs/gitignore).
+
+```
+*.rs
+*.toml
+*.lock
+static/**
+```


### PR DESCRIPTION
Ignore patterns from files in system directories with the `cargo-lambda` app name.
Ignore patterns from a `.cargolambdaignore` file in the root of the repository.
Ignore patterns from a file specified with the CARGO_LAMBDA_IGNORE_FILE environment variable.

Fixes #844 