### PR TITLE
Update `cargo-zigbuild` to `0.20.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-zigbuild"
-version = "0.19.7"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cc649328f39bbf1ef92ef753406e1785ff1074941c398e5214b6c74d318a9e"
+checksum = "3f6e9e856390d5b0a859acaeda16528f8a61c964bdb894c3216c254908f1c2ea"
 dependencies = [
  "anyhow",
  "cargo-config2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ cargo-lambda-system = { version = "1.8.4", path = "crates/cargo-lambda-system" }
 cargo-lambda-watch = { version = "1.8.4", path = "crates/cargo-lambda-watch" }
 cargo_metadata = "0.15.3"
 cargo-options = { version = "0.7.5", features = ["serde"] }
-cargo-zigbuild = "0.19.4"
+cargo-zigbuild = "0.20.0"
 clap = { version = "4.4.2", features = ["derive"] }
 chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
 dirs = "4"


### PR DESCRIPTION
Updating to 0.20.0 fixes an error on Rust nightly on Linux: [#334](https://github.com/rust-cross/cargo-zigbuild/pull/334)