### PR TITLE
fix: watch: add missing extension API endpoints for internal extension calls from inside functions

### DIFF
--- a/crates/cargo-lambda-watch/src/runtime/mod.rs
+++ b/crates/cargo-lambda-watch/src/runtime/mod.rs
@@ -16,8 +16,22 @@ pub(crate) const LAMBDA_RUNTIME_XRAY_TRACE_HEADER: &str = "lambda-runtime-trace-
 pub(crate) fn routes() -> Router<RefRuntimeState> {
     Router::new()
         .route("/2020-01-01/extension/register", post(register_extension))
+        // secondary route is for internal extensions
+        // that have the function name in their path
+        // (which we just discard currently)
+        .route(
+            "/:_function_name/2020-01-01/extension/register",
+            post(register_extension),
+        )
         .route(
             "/2020-01-01/extension/event/next",
+            get(next_extension_event),
+        )
+        // secondary route is for internal extensions
+        // that have the function name in their path
+        // (which we just discard currently)
+        .route(
+            "/:_function_name/2020-01-01/extension/event/next",
             get(next_extension_event),
         )
         .route("/2020-08-15/logs", put(subcribe_extension_events))


### PR DESCRIPTION
fixes: #848 

Currently, `cargo lambda watch` only exposes extension API routes for 'bare' endpoints that don't have function names in them, ie:
```
/2020-01-01/extension/register
/2020-01-01/extension/event/next
```

Meanwhile, when an internal extension (running in the same process as the primary function) makes API calls, it is prefixed with the function name, ie:
```
/_/2020-01-01/extension/register
/_/2020-01-01/extension/event/next
```

This causes any function-scoped extension calls to fall through to fallback handlers and error. In practice, this results in the function hanging on extension registration and the function never exiting the init phase.

This problem was alluded to when internal extension support was first added to the `aws-lambda-rust-runtime`:
https://github.com/awslabs/aws-lambda-rust-runtime/pull/744#issuecomment-1837286161

Meanwhile the Lambda orchestrator running in AWS does accept the function name-prefixed extension API calls.

Adding in support for this use case by adding the name-prefixed paths to our `watch` command's axum router, similar to how we have them for other (non-extension-related) routes.

## Testing

See #848  for full testing information.

In short, [this example](https://github.com/awslabs/aws-lambda-rust-runtime/blob/main/examples/extension-internal-flush/src/main.rs) from the `aws-lambda-rust-runtime`, previously hung indefinitely when run locally, but worked fine when deployed to AWS. It now runs properly locally.

I didn't update any unit test, integration tests, etc. Let me know if I should.