### PR TITLE
Fix conflicting short options

### DIFF
--- a/crates/cargo-lambda-invoke/src/lib.rs
+++ b/crates/cargo-lambda-invoke/src/lib.rs
@@ -41,7 +41,7 @@ pub struct Invoke {
     )]
     #[cfg_attr(
         not(target_os = "windows"),
-        arg(short = 'a', long, default_value = "::1")
+        arg(short = 'A', long, default_value = "::1")
     )]
     /// Local address host (IPv4 or IPv6) to send invoke requests
     invoke_address: String,

--- a/crates/cargo-lambda-invoke/src/lib.rs
+++ b/crates/cargo-lambda-invoke/src/lib.rs
@@ -47,7 +47,7 @@ pub struct Invoke {
     invoke_address: String,
 
     /// Local port to send invoke requests
-    #[arg(short = 'p', long, default_value = "9000")]
+    #[arg(short = 'P', long, default_value = "9000")]
     invoke_port: u16,
 
     /// File to read the invoke payload from

--- a/crates/cargo-lambda-metadata/src/cargo/watch.rs
+++ b/crates/cargo-lambda-metadata/src/cargo/watch.rs
@@ -44,7 +44,7 @@ pub struct Watch {
     #[serde(default)]
     pub only_lambda_apis: bool,
 
-    #[arg(short = 'a', long, default_value = DEFAULT_INVOKE_ADDRESS)]
+    #[arg(short = 'A', long, default_value = DEFAULT_INVOKE_ADDRESS)]
     #[serde(default = "default_invoke_address")]
     /// Address where users send invoke requests
     pub invoke_address: String,


### PR DESCRIPTION
Currently, a couple of the short options for the `invoke` subcommand are in conflict.

Just to be sure, I went through all the subcommand short options to see if there were any others:

 Option | `build` | `deploy` | `watch` | `init` | `invoke` | `new` | `system`
-- | -- | -- | -- | -- | -- | -- | --
`-a` | — | `alias` | `invoke-address` | — | ⛔️ `invoke-address` / `alias` | — | —
`-c` | `compiler` | — | — | — | — | — | —
`-h` | `help` | `help` | `help` | `help` | `help` | `help` | `help`
`-i` | `include` | `include` | — | — | — | — | —
`-j` | `jobs` | — | `jobs` | — | — | — | —
`-l` | `lambda-dir` | `lambda-dir` | — | — | — | — | —
`-m` | — | — | — | — | — | — | `manifest-path`
`-o` | `output-format` | `output-format` | — | `open` | `output-format` | `open` | `output-format`
`-p` | `package` | `profile` | `package` | — | ⛔️ `invoke-port` / `profile` | — | `package`
`-q` | `quiet` | — | `quiet` | — | — | — | —
`-r` | `release` | `region` | `release` | — | `region` | — | —
`-v` | `verbose` | `verbose` | `verbose` | `verbose` | `verbose` | `verbose` | `verbose`
`-w` | — | — | `wait` | — | — | — | —
`-x` | `context` | `context` | `context` | `context` | `context` | `context` | `context`
`-y` | — | — | — | `no-interactive` | — | `no-interactive` | —
`-A` | — | — | — | — | `data-ascii` | — | —
`-E` | — | — | — | — | `data-example` | — | —
`-F` | `features` | — | `features` | — | `data-file` | — | —
`-P` | — | — | `invoke-port` | — | — | — | —
`-R` | — | — | — | — | `remote` | — | —
`-Z` | `flag` | — | `flag` | — | — | — | —

As you can see, it's just `-a` and `-p` on `invoke` that are a problem.

I updated:

  - `--invoke-port` on `invoke` to use `-P` (so that it matches with e.g. the `watch` subcommand); and
  - `--invoke-address` on `invoke` to use `-A` (to match `-P`); and
  - `--invoke-address` on `watch` to use `-A` (to match the two above).

Fixes #857.