### PR TITLE
fix(deploy): allow to set iam role tags when created

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,6 +1338,7 @@ dependencies = [
  "miette 5.10.0",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "tempfile",
  "tokio",
  "tracing",
@@ -1434,6 +1435,7 @@ version = "1.8.5"
 dependencies = [
  "aws-config",
  "aws-credential-types",
+ "aws-sdk-iam",
  "aws-sdk-lambda",
  "aws-types",
  "clap",

--- a/crates/cargo-lambda-deploy/Cargo.toml
+++ b/crates/cargo-lambda-deploy/Cargo.toml
@@ -24,7 +24,7 @@ cargo-lambda-remote.workspace = true
 miette.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["time"]}
+tokio = { workspace = true, features = ["time"] }
 tracing.workspace = true
 uuid.workspace = true
 
@@ -35,5 +35,6 @@ aws-smithy-runtime.workspace = true
 base64.workspace = true
 http = "1.0"
 serde_json.workspace = true
+serde_urlencoded = "0.7.1"
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/cargo-lambda-deploy/src/functions.rs
+++ b/crates/cargo-lambda-deploy/src/functions.rs
@@ -138,7 +138,7 @@ async fn upsert_function(
     let (arn, version) = match action {
         FunctionAction::Create => {
             let function_role = match &config.function_config.role {
-                None => roles::create(sdk_config, progress).await?,
+                None => roles::create(config, sdk_config, progress).await?,
                 Some(role) => FunctionRole::from_existing(role.clone()),
             };
 

--- a/crates/cargo-lambda-metadata/src/cargo/deploy.rs
+++ b/crates/cargo-lambda-metadata/src/cargo/deploy.rs
@@ -1,5 +1,6 @@
 use cargo_lambda_remote::{
     RemoteConfig,
+    aws_sdk_iam::types::Tag,
     aws_sdk_lambda::types::{Environment, TracingConfig},
 };
 use clap::{ArgAction, Args, ValueHint};
@@ -159,6 +160,20 @@ impl Deploy {
             None => None,
             Some(tags) if tags.is_empty() => None,
             Some(tags) => Some(tags.join("&")),
+        }
+    }
+
+    pub fn iam_tags(&self) -> Option<Vec<Tag>> {
+        match &self.tag {
+            None => None,
+            Some(tags) if tags.is_empty() => None,
+            Some(tags) => Some(
+                extract_tags(tags)
+                    .into_iter()
+                    .map(|(k, v)| Tag::builder().key(k).value(v).build())
+                    .collect::<Result<Vec<_>, _>>()
+                    .expect("failed to build IAM tags"),
+            ),
         }
     }
 

--- a/crates/cargo-lambda-remote/Cargo.toml
+++ b/crates/cargo-lambda-remote/Cargo.toml
@@ -13,6 +13,7 @@ description.workspace = true
 
 [dependencies]
 aws-config.workspace = true
+aws-sdk-iam.workspace = true
 aws-sdk-lambda.workspace = true
 aws-types.workspace = true
 clap.workspace = true

--- a/crates/cargo-lambda-remote/src/lib.rs
+++ b/crates/cargo-lambda-remote/src/lib.rs
@@ -127,6 +127,7 @@ impl RemoteConfig {
 pub mod aws_sdk_config {
     pub use aws_types::SdkConfig;
 }
+pub use aws_sdk_iam;
 pub use aws_sdk_lambda;
 
 #[cfg(test)]


### PR DESCRIPTION
to have better overview in the [AWS Resource Explorer](https://resource-explorer.console.aws.amazon.com/resource-explorer/home?region=eu-central-1#/home) what resources was created by the cargo-lambda, I'm adding tags for the iam role created during deploy

here is how it works:
1. deploy with tags
```sh
❯ cargo lambda deploy --tags cargo:service-name=s3-to-sns
✅ function deployed successfully 🎉
🛠️  binary last compiled 2 days ago
🔍 arn: arn:aws:lambda:eu-central-1:<REDACTED>:function:s3-to-sns
🎭 version: 3
```
2. the role tags
<img width="830" height="532" alt="image" src="https://github.com/user-attachments/assets/a7a26e4c-8ce0-4372-99dd-21dab5bb836b" />
