### PR TITLE
Fix issue reading metadata with package name.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ exclude = [
     "tests/fixtures/watch-multi-binary",
     "tests/fixtures/package-with-global-config",
     "tests/fixtures/config-with-context",
+    "tests/fixtures/workspace-with-package-config",
 ]
 
 resolver = "2"

--- a/crates/cargo-lambda-build/src/compiler/cross.rs
+++ b/crates/cargo-lambda-build/src/compiler/cross.rs
@@ -42,7 +42,7 @@ fn default_cross_image(target: &str, metadata: &CargoMetadata) -> Option<(String
         return None;
     }
 
-    let env_value = format!("ghcr.io/cross-rs/{}:0.2.5", target);
+    let env_value = format!("ghcr.io/cross-rs/{target}:0.2.5");
     Some((env_name, env_value))
 }
 

--- a/crates/cargo-lambda-cli/tests/cargo_lambda.rs
+++ b/crates/cargo-lambda-cli/tests/cargo_lambda.rs
@@ -23,7 +23,7 @@ fn test_build_basic_function() {
     cargo_lambda_build(project.root()).assert().success();
 
     let bin = project.lambda_function_bin(&lp.name);
-    assert!(bin.exists(), "{:?} doesn't exist", bin);
+    assert!(bin.exists(), "{bin:?} doesn't exist");
 
     #[cfg(not(windows))]
     {
@@ -54,7 +54,7 @@ fn test_build_basic_zip_function() {
         .success();
 
     let bin = project.lambda_function_zip(&lp.name);
-    assert!(bin.exists(), "{:?} doesn't exist", bin);
+    assert!(bin.exists(), "{bin:?} doesn't exist");
     let file = File::open(bin).expect("failed to open zip file");
     let mut zip = ZipArchive::new(file).expect("failed to initialize the zip archive");
     assert!(
@@ -82,7 +82,7 @@ fn test_build_basic_zip_function_with_include() {
         .success();
 
     let bin = project.lambda_function_zip(&lp.name);
-    assert!(bin.exists(), "{:?} doesn't exist", bin);
+    assert!(bin.exists(), "{bin:?} doesn't exist");
     let file = File::open(bin).expect("failed to open zip file");
     let mut zip = ZipArchive::new(file).expect("failed to initialize the zip archive");
     assert!(
@@ -108,7 +108,7 @@ fn test_build_http_function() {
     cargo_lambda_build(project.root()).assert().success();
 
     let bin = project.lambda_function_bin(&lp.name);
-    assert!(bin.exists(), "{:?} doesn't exist", bin);
+    assert!(bin.exists(), "{bin:?} doesn't exist");
 
     #[cfg(not(windows))]
     {
@@ -137,7 +137,7 @@ fn test_build_http_feature_function() {
     cargo_lambda_build(project.root()).assert().success();
 
     let bin = project.lambda_function_bin(&lp.name);
-    assert!(bin.exists(), "{:?} doesn't exist", bin);
+    assert!(bin.exists(), "{bin:?} doesn't exist");
 }
 
 #[test]
@@ -156,7 +156,7 @@ fn test_build_event_type_function() {
     cargo_lambda_build(project.root()).assert().success();
 
     let bin = project.lambda_function_bin(&lp.name);
-    assert!(bin.exists(), "{:?} doesn't exist", bin);
+    assert!(bin.exists(), "{bin:?} doesn't exist");
 }
 
 #[test]
@@ -177,7 +177,7 @@ fn test_build_basic_extension() {
         .success();
 
     let bin = project.lambda_extension_bin(&lp.name);
-    assert!(bin.exists(), "{:?} doesn't exist", bin);
+    assert!(bin.exists(), "{bin:?} doesn't exist");
 
     #[cfg(not(windows))]
     cargo_lambda_dry_deploy(project.root())
@@ -206,7 +206,7 @@ fn test_build_logs_extension() {
         .success();
 
     let bin = project.lambda_extension_bin(&lp.name);
-    assert!(bin.exists(), "{:?} doesn't exist", bin);
+    assert!(bin.exists(), "{bin:?} doesn't exist");
 }
 
 #[test]
@@ -228,7 +228,7 @@ fn test_build_telemetry_extension() {
         .success();
 
     let bin = project.lambda_extension_bin(&lp.name);
-    assert!(bin.exists(), "{:?} doesn't exist", bin);
+    assert!(bin.exists(), "{bin:?} doesn't exist");
 }
 
 #[test]
@@ -248,7 +248,7 @@ fn test_init_subcommand() {
     cargo_lambda_build(project.root()).assert().success();
 
     let bin = project.lambda_function_bin(&lp.name);
-    assert!(bin.exists(), "{:?} doesn't exist", bin);
+    assert!(bin.exists(), "{bin:?} doesn't exist");
 }
 
 #[test]
@@ -376,10 +376,10 @@ fn test_build_example() {
         .success();
 
     let bin = project.lambda_function_bin("example-lambda");
-    assert!(bin.exists(), "{:?} doesn't exist", bin);
+    assert!(bin.exists(), "{bin:?} doesn't exist");
 
     let bin = project.lambda_function_bin(&lp.name);
-    assert!(!bin.exists(), "{:?} exists, but it shoudn't", bin);
+    assert!(!bin.exists(), "{bin:?} exists, but it shoudn't");
 
     #[cfg(not(windows))]
     cargo_lambda_dry_deploy(project.root())
@@ -394,7 +394,7 @@ fn test_build_example() {
     cargo_lambda_build(project.root()).assert().success();
 
     let bin = project.lambda_function_bin("example-lambda");
-    assert!(!bin.exists(), "{:?} exists, but it shouldn't", bin);
+    assert!(!bin.exists(), "{bin:?} exists, but it shouldn't");
 
     let bin = project.lambda_function_bin(&lp.name);
     assert!(
@@ -508,18 +508,18 @@ members = ["crates/{}", "crates/{}"]
     // Build all binaries first. The second build should zip only one of them.
     cargo_lambda_build(workspace.root()).assert().success();
     let lp_1_bin = workspace.lambda_function_zip(&lp_1.name);
-    assert!(!lp_1_bin.exists(), "{:?} exist", lp_1_bin);
+    assert!(!lp_1_bin.exists(), "{lp_1_bin:?} exist");
     let lp_2_bin = workspace.lambda_function_zip(&lp_2.name);
-    assert!(!lp_2_bin.exists(), "{:?} exist", lp_2_bin);
+    assert!(!lp_2_bin.exists(), "{lp_2_bin:?} exist");
 
     cargo_lambda_build(workspace.root())
         .args(["--bin", &lp_1.name, "--output-format", "zip"])
         .assert()
         .success();
 
-    assert!(lp_1_bin.exists(), "{:?} doesn't exist", lp_1_bin);
+    assert!(lp_1_bin.exists(), "{lp_1_bin:?} doesn't exist");
     // The second zip file should not be created because we're using `--bin`.
-    assert!(!lp_2_bin.exists(), "{:?} exist", lp_2_bin);
+    assert!(!lp_2_bin.exists(), "{lp_2_bin:?} exist");
 }
 
 #[test]
@@ -571,7 +571,7 @@ fn test_deploy_function_with_extra_files() {
     cargo_lambda_build(project.root()).assert().success();
 
     let bin = project.lambda_function_bin(&lp.name);
-    assert!(bin.exists(), "{:?} doesn't exist", bin);
+    assert!(bin.exists(), "{bin:?} doesn't exist");
 
     #[cfg(not(windows))]
     {
@@ -688,10 +688,10 @@ fn test_deploy_pre_existing_zip_file() {
         .success();
 
     let bin = project.lambda_function_bin(&lp.name);
-    assert!(!bin.exists(), "{:?} exist", bin);
+    assert!(!bin.exists(), "{bin:?} exist");
 
     let zip_path = project.lambda_function_zip(&lp.name);
-    assert!(zip_path.exists(), "{:?} doesn't exist", zip_path);
+    assert!(zip_path.exists(), "{zip_path:?} doesn't exist");
 
     #[cfg(not(windows))]
     {
@@ -743,7 +743,7 @@ fn test_deploy_with_sdk_and_vpc_cli_flags() {
     cargo_lambda_build(project.root()).assert().success();
 
     let bin = project.lambda_function_bin(&lp.name);
-    assert!(bin.exists(), "{:?} doesn't exist", bin);
+    assert!(bin.exists(), "{bin:?} doesn't exist");
 
     #[cfg(not(windows))]
     {

--- a/crates/cargo-lambda-cli/tests/harness/project.rs
+++ b/crates/cargo-lambda-cli/tests/harness/project.rs
@@ -161,7 +161,7 @@ impl CargoPathExt for Path {
                 if e.kind() == ErrorKind::NotFound {
                     return;
                 }
-                panic!("failed to remove {:?}, could not read: {:?}", self, e);
+                panic!("failed to remove {self:?}, could not read: {e:?}");
             }
         };
         // There is a race condition between fetching the metadata and
@@ -169,10 +169,10 @@ impl CargoPathExt for Path {
         // for our tests.
         if meta.is_dir() {
             if let Err(e) = fs::remove_dir_all(self) {
-                panic!("failed to remove {:?}: {:?}", self, e)
+                panic!("failed to remove {self:?}: {e:?}")
             }
         } else if let Err(e) = fs::remove_file(self) {
-            panic!("failed to remove {:?}: {:?}", self, e)
+            panic!("failed to remove {self:?}: {e:?}")
         }
     }
 
@@ -242,7 +242,7 @@ pub mod paths {
         });
 
         let mut root = global_root();
-        root.push(format!("t{}", id));
+        root.push(format!("t{id}"));
         root
     }
 

--- a/crates/cargo-lambda-deploy/src/dry.rs
+++ b/crates/cargo-lambda-deploy/src/dry.rs
@@ -63,7 +63,7 @@ impl Display for DeployOutput {
         }
 
         if let Some(bucket) = &self.bucket {
-            writeln!(f, "🪣 stored on S3 bucket `{}`", bucket)?;
+            writeln!(f, "🪣 stored on S3 bucket `{bucket}`")?;
         }
 
         if !self.runtimes.is_empty() {
@@ -73,7 +73,7 @@ impl Display for DeployOutput {
         if !self.files.is_empty() {
             writeln!(f, "🗃️  files included in the zip file:")?;
             for file in &self.files {
-                writeln!(f, "  - {}", file)?;
+                writeln!(f, "  - {file}")?;
             }
         }
 
@@ -84,10 +84,10 @@ impl Display for DeployOutput {
             self.sdk_config.region.as_deref().unwrap_or(DEFAULT_REGION)
         )?;
         if let Some(profile) = &self.sdk_config.profile {
-            writeln!(f, "  - profile: {}", profile)?;
+            writeln!(f, "  - profile: {profile}")?;
         }
         if let Some(endpoint_url) = &self.sdk_config.endpoint_url {
-            writeln!(f, "  - endpoint: {}", endpoint_url)?;
+            writeln!(f, "  - endpoint: {endpoint_url}")?;
         }
 
         if self.kind == DeployKind::Function {
@@ -123,7 +123,7 @@ impl Display for DeployOutput {
                 let env = env_options
                     .lambda_environment(&HashMap::new())
                     .unwrap_or_default();
-                writeln!(f, "  - env_options: {:?}", env)?;
+                writeln!(f, "  - env_options: {env:?}")?;
             }
         }
 

--- a/crates/cargo-lambda-interactive/src/command.rs
+++ b/crates/cargo-lambda-interactive/src/command.rs
@@ -88,7 +88,7 @@ impl std::fmt::Display for CommandError {
         write!(f, "Command `{}` failed", self.command)?;
 
         if let Some(error) = &self.error {
-            write!(f, ": {}", error)?;
+            write!(f, ": {error}")?;
         }
 
         if !self.stdout.is_empty() {

--- a/crates/cargo-lambda-metadata/src/cargo/build.rs
+++ b/crates/cargo-lambda-metadata/src/cargo/build.rs
@@ -131,6 +131,22 @@ impl Build {
     pub fn output_format(&self) -> &OutputFormat {
         self.output_format.as_ref().unwrap_or(&OutputFormat::Binary)
     }
+
+    /// Returns the package name if there is only one package in the list of `packages`,
+    /// otherwise None.
+    pub fn pkg_name(&self) -> Option<String> {
+        if self.cargo_opts.packages.len() > 1 {
+            return None;
+        }
+        self.cargo_opts.packages.first().map(|s| s.to_string())
+    }
+
+    pub fn bin_name(&self) -> Option<String> {
+        if self.cargo_opts.bin.len() > 1 {
+            return None;
+        }
+        self.cargo_opts.bin.first().map(|s| s.to_string())
+    }
 }
 
 impl Serialize for Build {

--- a/crates/cargo-lambda-metadata/src/cargo/deploy.rs
+++ b/crates/cargo-lambda-metadata/src/cargo/deploy.rs
@@ -515,7 +515,7 @@ fn extract_tags(tags: &Vec<String>) -> HashMap<String, String> {
 mod tests {
     use crate::{
         cargo::load_metadata,
-        config::{ConfigOptions, load_config_without_cli_flags},
+        config::{ConfigOptions, FunctionNames, load_config_without_cli_flags},
         lambda::Timeout,
         tests::fixture_metadata,
     };
@@ -620,7 +620,7 @@ mod tests {
     #[test]
     fn test_load_config_from_workspace() {
         let options = ConfigOptions {
-            name: Some("crate-3".to_string()),
+            names: FunctionNames::from_package("crate-3"),
             admerge: true,
             ..Default::default()
         };

--- a/crates/cargo-lambda-metadata/src/cargo/mod.rs
+++ b/crates/cargo-lambda-metadata/src/cargo/mod.rs
@@ -405,7 +405,7 @@ mod tests {
     fn test_binary_packages_with_mixed_workspace() {
         let bins = binary_targets(fixture_metadata("mixed-workspace-package"), false).unwrap();
         assert_eq!(1, bins.len());
-        assert!(bins.contains("function-crate"), "{:?}", bins);
+        assert!(bins.contains("function-crate"), "{bins:?}");
     }
 
     #[test]

--- a/crates/cargo-lambda-metadata/src/cargo/watch.rs
+++ b/crates/cargo-lambda-metadata/src/cargo/watch.rs
@@ -101,11 +101,18 @@ impl Watch {
 
     /// Returns the package name if there is only one package in the list of `packages`,
     /// otherwise None.
-    pub fn package(&self) -> Option<String> {
+    pub fn pkg_name(&self) -> Option<String> {
         if self.cargo_opts.packages.len() > 1 {
             return None;
         }
         self.cargo_opts.packages.first().map(|s| s.to_string())
+    }
+
+    pub fn bin_name(&self) -> Option<String> {
+        if self.cargo_opts.bin.len() > 1 {
+            return None;
+        }
+        self.cargo_opts.bin.first().map(|s| s.to_string())
     }
 
     pub fn lambda_environment(

--- a/crates/cargo-lambda-new/src/extensions.rs
+++ b/crates/cargo-lambda-new/src/extensions.rs
@@ -83,7 +83,7 @@ mod test {
         ];
 
         for (opt, exp) in cases {
-            assert_eq!(exp, opt.add_events_extension(), "options: {:?}", opt);
+            assert_eq!(exp, opt.add_events_extension(), "options: {opt:?}");
         }
     }
 }

--- a/crates/cargo-lambda-new/src/template.rs
+++ b/crates/cargo-lambda-new/src/template.rs
@@ -231,8 +231,8 @@ fn adjust_remote_zip_base(url: &str, path: &Path) -> Option<PathBuf> {
     if let Some(caps) = archive_regex.captures(url) {
         let repo = caps.name("repo")?.as_str();
         let reference = caps.name("ref")?.as_str();
-        let reference = reference.replace(&format!("{}-", repo), "");
-        let base_dir = format!("{}-{}", repo, reference);
+        let reference = reference.replace(&format!("{repo}-"), "");
+        let base_dir = format!("{repo}-{reference}");
 
         let base_path = path.join(&base_dir);
         tracing::trace!(

--- a/crates/cargo-lambda-new/src/template/config.rs
+++ b/crates/cargo-lambda-new/src/template/config.rs
@@ -172,10 +172,9 @@ impl TemplatePrompt {
 
     fn help_message(&self) -> Option<String> {
         match (self.choices.is_some(), &self.help) {
-            (true, Some(user_help)) => Some(format!(
-                "{PROMPT_WITH_OPTIONS_HELP_MESSAGE}.\n{}",
-                user_help
-            )),
+            (true, Some(user_help)) => {
+                Some(format!("{PROMPT_WITH_OPTIONS_HELP_MESSAGE}.\n{user_help}"))
+            }
             (true, None) => Some(PROMPT_WITH_OPTIONS_HELP_MESSAGE.to_string()),
             (false, Some(user_help)) => Some(user_help.clone()),
             (false, None) => None,

--- a/crates/cargo-lambda-system/src/lib.rs
+++ b/crates/cargo-lambda-system/src/lib.rs
@@ -54,7 +54,7 @@ impl System {
             .unwrap_or_else(|| "Cargo.toml".into())
     }
 
-    pub fn package(&self) -> Option<String> {
+    pub fn pkg_name(&self) -> Option<String> {
         self.package.clone()
     }
 }
@@ -95,7 +95,7 @@ pub async fn run(config: &System, options: &ConfigOptions) -> Result<()> {
     if manifest_path.exists() {
         let metadata = load_metadata(manifest_path)?;
 
-        let config_info = if options.name.is_some() || metadata.packages.len() == 1 {
+        let config_info = if !options.names.is_empty() || metadata.packages.len() == 1 {
             let config = load_config_without_cli_flags(&metadata, options)?;
             ConfigInfo::Package(config)
         } else {

--- a/crates/cargo-lambda-watch/src/error.rs
+++ b/crates/cargo-lambda-watch/src/error.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 
 use crate::requests::{Action, InvokeRequest, NextEvent};
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Diagnostic, Error)]
 pub enum ServerError {
     #[error("failed to build a response")]

--- a/crates/cargo-lambda-watch/src/lib.rs
+++ b/crates/cargo-lambda-watch/src/lib.rs
@@ -379,7 +379,7 @@ async fn proxy(
 
     connection_tracker.spawn(async move {
         if let Err(err) = conn.await {
-            println!("Connection failed: {:?}", err);
+            println!("Connection failed: {err:?}");
         }
     });
 

--- a/crates/cargo-lambda-watch/src/requests.rs
+++ b/crates/cargo-lambda-watch/src/requests.rs
@@ -13,6 +13,7 @@ pub(crate) const AWS_XRAY_TRACE_HEADER: &str = "x-amzn-trace-id";
 /// model, this response is represented as a HTTP Request data object.
 pub type LambdaResponse = Request<Body>;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum Action {
     Invoke(InvokeRequest),

--- a/crates/cargo-lambda-watch/src/scheduler.rs
+++ b/crates/cargo-lambda-watch/src/scheduler.rs
@@ -116,6 +116,7 @@ fn is_valid_bin_name(name: &str) -> bool {
     !name.is_empty() && name != DEFAULT_PACKAGE_FUNCTION
 }
 
+#[allow(clippy::result_large_err)]
 fn cargo_command(
     name: &str,
     cargo_options: &CargoOptions,

--- a/crates/cargo-lambda-watch/src/trigger_router.rs
+++ b/crates/cargo-lambda-watch/src/trigger_router.rs
@@ -412,6 +412,7 @@ async fn create_buffered_response(
     Ok((status, resp_body))
 }
 
+#[allow(clippy::result_large_err)]
 fn respond_with_disabled_default_function(
     state: &RefRuntimeState,
     invoke_call: bool,
@@ -436,6 +437,7 @@ fn respond_with_disabled_default_function(
         .map_err(ServerError::ResponseBuild)
 }
 
+#[allow(clippy::result_large_err)]
 fn respond_with_missing_function(
     binaries: &HashSet<String>,
 ) -> Result<Response<Body>, ServerError> {

--- a/crates/cargo-lambda-watch/src/watcher.rs
+++ b/crates/cargo-lambda-watch/src/watcher.rs
@@ -1,7 +1,7 @@
 use crate::{error::ServerError, requests::NextEvent, state::ExtensionCache};
 use cargo_lambda_metadata::{
     cargo::load_metadata,
-    config::{ConfigOptions, load_config_without_cli_flags},
+    config::{ConfigOptions, FunctionNames, load_config_without_cli_flags},
 };
 use ignore::create_filter;
 use ignore_files::IgnoreFile;
@@ -263,7 +263,7 @@ fn reload_env(manifest_path: &PathBuf, bin_name: &Option<String>) -> HashMap<Str
     };
 
     let options = ConfigOptions {
-        name: bin_name.clone(),
+        names: FunctionNames::new(None, bin_name.clone()),
         ..Default::default()
     };
     let config = match load_config_without_cli_flags(&metadata, &options) {

--- a/tests/fixtures/workspace-with-package-config/Cargo.toml
+++ b/tests/fixtures/workspace-with-package-config/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+resolver = "2"
+members = ["package-1"]

--- a/tests/fixtures/workspace-with-package-config/package-1/Cargo.toml
+++ b/tests/fixtures/workspace-with-package-config/package-1/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "package-1"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.lambda.build]
+output_format = "zip"
+features = ["lol"]
+
+[features]
+lol = []
+
+[[bin]]
+name = "binary-function-1"
+path = "src/main.rs"
+test = false


### PR DESCRIPTION
This change collects both package and binary names to load package metadata correctly.

This also fixes a bunch of new clippy warnings from new Rust versions.

Fixes #866 