### PR TITLE
Remap content-length in streaming response headers.

### DIFF
--- a/crates/cargo-lambda-watch/src/trigger_router.rs
+++ b/crates/cargo-lambda-watch/src/trigger_router.rs
@@ -339,6 +339,9 @@ async fn create_streaming_response(
 
     if let Some(headers) = builder.headers_mut() {
         headers.extend(prelude.headers);
+        if let Some(content_length) = headers.remove("content-length") {
+            headers.insert("x-amzn-remapped-content-length", content_length);
+        }
 
         prelude.cookies.iter().try_for_each(|cookie| {
             let header_value =


### PR DESCRIPTION
Remove the content-length header to ensure the client doesn't terminate the connection when a function is streaming a response.

Fixes https://github.com/cargo-lambda/cargo-lambda/issues/862