### PR TITLE
fix: Removed deprecated cargo_bin() function in snapbox

### DIFF
--- a/crates/cargo-lambda-cli/tests/harness/mod.rs
+++ b/crates/cargo-lambda-cli/tests/harness/mod.rs
@@ -135,7 +135,7 @@ pub fn cargo_lambda_dry_deploy<P: AsRef<Path>>(path: P) -> Command {
 }
 
 fn cargo_exe() -> std::path::PathBuf {
-    snapbox::cmd::cargo_bin("cargo-lambda")
+    snapbox::cmd::cargo_bin!("cargo-lambda").to_path_buf()
 }
 
 pub trait LambdaCommandExt {


### PR DESCRIPTION
See the deprecation notice in the [snapbox docs](https://docs.rs/snapbox/latest/snapbox/cmd/fn.cargo_bin.html).

fixes #900 