### PR TITLE
Remove channel check from toolchain installation.

### DIFF
--- a/crates/cargo-lambda-build/src/target_arch.rs
+++ b/crates/cargo-lambda-build/src/target_arch.rs
@@ -1,7 +1,6 @@
 use std::{fmt::Display, str::FromStr};
 
 use miette::{Context, IntoDiagnostic, Result};
-use rustc_version::Channel;
 
 use crate::error::BuildError;
 
@@ -27,21 +26,18 @@ impl Arch {
 #[derive(Debug)]
 pub struct TargetArch {
     rustc_target: String,
-    channel: Option<Channel>,
 }
 
 impl TargetArch {
     pub fn arm64() -> Self {
         Self {
             rustc_target: TARGET_ARM.into(),
-            channel: None,
         }
     }
 
     pub fn x86_64() -> Self {
         Self {
             rustc_target: TARGET_X86_64.into(),
-            channel: None,
         }
     }
 
@@ -53,7 +49,6 @@ impl TargetArch {
         if !target.compatible_host_linker() {
             target = TargetArch::x86_64();
         }
-        target.channel = Some(rustc_meta.channel);
         Ok(target)
     }
 
@@ -85,16 +80,6 @@ impl TargetArch {
         false
     }
 
-    pub fn channel(&self) -> Result<Channel> {
-        match self.channel {
-            Some(c) => Ok(c),
-            None => rustc_version::version_meta()
-                .map(|m| m.channel)
-                .into_diagnostic()
-                .wrap_err("error reading Rust version information"),
-        }
-    }
-
     pub fn rustc_target_without_glibc_version(&self) -> &str {
         let Some((rustc_target_without_glibc_version, _)) = self.rustc_target.split_once('.')
         else {
@@ -117,7 +102,6 @@ impl FromStr for TargetArch {
     fn from_str(host: &str) -> Result<Self, Self::Err> {
         Ok(Self {
             rustc_target: host.into(),
-            channel: None,
         })
     }
 }

--- a/crates/cargo-lambda-build/src/toolchain.rs
+++ b/crates/cargo-lambda-build/src/toolchain.rs
@@ -3,7 +3,6 @@ use cargo_lambda_interactive::{
     progress::Progress,
 };
 use miette::{IntoDiagnostic, Result, WrapErr};
-use rustc_version::Channel;
 use std::{env, str};
 
 use crate::target_arch::TargetArch;
@@ -13,16 +12,8 @@ use crate::target_arch::TargetArch;
 pub async fn check_target_component_with_rustc_meta(target_arch: &TargetArch) -> Result<()> {
     let component = target_arch.rustc_target_without_glibc_version();
 
-    // convert `Channel` enum to a lower-cased string representation
-    let toolchain = match target_arch.channel()? {
-        Channel::Stable => "stable",
-        Channel::Nightly => "nightly",
-        Channel::Dev => "dev",
-        Channel::Beta => "beta",
-    };
-
     let cmd = rustup_cmd();
-    let args = [&format!("+{toolchain}"), "target", "list", "--installed"];
+    let args = ["target", "list", "--installed"];
 
     tracing::trace!(
         cmd = ?cmd,
@@ -49,7 +40,7 @@ pub async fn check_target_component_with_rustc_meta(target_arch: &TargetArch) ->
         // install target component using `rustup`
         let pb = Progress::start(format!("Installing target component `{component}`..."));
 
-        let result = install_target_component(component, toolchain).await;
+        let result = install_target_component(component).await;
         let finish = if result.is_ok() {
             "Target component installed"
         } else {
@@ -63,9 +54,9 @@ pub async fn check_target_component_with_rustc_meta(target_arch: &TargetArch) ->
 }
 
 /// Install target component in the host toolchain, using `rustup target add`
-async fn install_target_component(component: &str, toolchain: &str) -> Result<()> {
+async fn install_target_component(component: &str) -> Result<()> {
     let cmd = rustup_cmd();
-    let args = [&format!("+{toolchain}"), "target", "add", component];
+    let args = ["target", "add", component];
     tracing::trace!(
         cmd = ?cmd,
         args = ?args,


### PR DESCRIPTION
Let rustup use the selected channel for the project it's in. This way if you're using a custom channel, the toolchain will be installed on it.

Fixes https://github.com/cargo-lambda/cargo-lambda/issues/894