### PR TITLE
Implement concurrent watchers.

### DIFF
--- a/crates/cargo-lambda-metadata/src/config.rs
+++ b/crates/cargo-lambda-metadata/src/config.rs
@@ -551,4 +551,51 @@ mod tests {
         );
         assert_eq!(config.build.output_format, Some(OutputFormat::Zip));
     }
+
+    #[test]
+    fn test_load_concurrency_from_metadata() {
+        let metadata = load_metadata(fixture_metadata("single-binary-package")).unwrap();
+        let config = load_config_without_cli_flags(&metadata, &ConfigOptions::default()).unwrap();
+
+        assert_eq!(
+            config.watch.concurrency, 5,
+            "concurrency should be loaded from package metadata"
+        );
+    }
+
+    #[test]
+    fn test_concurrency_cli_override() {
+        let metadata = load_metadata(fixture_metadata("single-binary-package")).unwrap();
+
+        let mut watch = Watch::default();
+        watch.concurrency = 10;
+
+        let args_config = Config {
+            watch,
+            ..Default::default()
+        };
+
+        let config = load_config(&args_config, &metadata, &ConfigOptions::default()).unwrap();
+
+        assert_eq!(
+            config.watch.concurrency, 10,
+            "CLI concurrency should override Cargo.toml metadata"
+        );
+    }
+
+    #[test]
+    fn test_load_concurrency_from_workspace_metadata() {
+        let options = ConfigOptions {
+            names: FunctionNames::from_package("crate-1"),
+            ..Default::default()
+        };
+
+        let metadata = load_metadata(fixture_metadata("workspace-package")).unwrap();
+        let config = load_config_without_cli_flags(&metadata, &options).unwrap();
+
+        assert_eq!(
+            config.watch.concurrency, 3,
+            "concurrency should be loaded from workspace metadata"
+        );
+    }
 }

--- a/crates/cargo-lambda-watch/src/instance_pool.rs
+++ b/crates/cargo-lambda-watch/src/instance_pool.rs
@@ -1,0 +1,184 @@
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+pub type InstanceId = Uuid;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum InstanceStatus {
+    Starting,
+    Idle,
+    Busy,
+}
+
+#[derive(Clone, Debug)]
+pub struct FunctionInstance {
+    pub id: InstanceId,
+    pub status: InstanceStatus,
+    pub requests_processed: u64,
+}
+
+impl FunctionInstance {
+    pub fn new(id: InstanceId) -> Self {
+        Self {
+            id,
+            status: InstanceStatus::Starting,
+            requests_processed: 0,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct InstancePool {
+    instances: Arc<RwLock<HashMap<InstanceId, FunctionInstance>>>,
+    max_concurrency: usize,
+}
+
+impl InstancePool {
+    pub fn new(max_concurrency: usize) -> Self {
+        Self {
+            instances: Arc::new(RwLock::new(HashMap::new())),
+            max_concurrency,
+        }
+    }
+
+    /// Returns true if a new instance should be spawned based on queue depth and current capacity
+    pub async fn should_spawn_instance(&self, queue_depth: usize) -> bool {
+        if queue_depth == 0 {
+            return false;
+        }
+
+        let instances = self.instances.read().await;
+        let current_count = instances.len();
+
+        if current_count >= self.max_concurrency {
+            return false;
+        }
+
+        let idle_count = instances
+            .values()
+            .filter(|inst| inst.status == InstanceStatus::Idle)
+            .count();
+
+        idle_count == 0
+    }
+
+    /// Mark instance as busy (processing a request)
+    pub async fn mark_busy(&self, instance_id: &InstanceId) {
+        let mut instances = self.instances.write().await;
+        if let Some(instance) = instances.get_mut(instance_id) {
+            instance.status = InstanceStatus::Busy;
+            instance.requests_processed += 1;
+        }
+    }
+
+    /// Mark instance as idle (waiting for requests)
+    pub async fn mark_idle(&self, instance_id: &InstanceId) {
+        let mut instances = self.instances.write().await;
+        if let Some(instance) = instances.get_mut(instance_id) {
+            instance.status = InstanceStatus::Idle;
+        }
+    }
+
+    /// Add a new instance to the pool
+    pub async fn add_instance(&self, instance: FunctionInstance) {
+        let mut instances = self.instances.write().await;
+        instances.insert(instance.id, instance);
+    }
+
+    /// Remove an instance from the pool (e.g., crashed or dead)
+    pub async fn remove_instance(&self, instance_id: &InstanceId) -> Option<FunctionInstance> {
+        let mut instances = self.instances.write().await;
+        instances.remove(instance_id)
+    }
+
+    /// Get the current count of instances
+    pub async fn instance_count(&self) -> usize {
+        let instances = self.instances.read().await;
+        instances.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_should_spawn_instance_first_request() {
+        let pool = InstancePool::new(3);
+        assert!(!pool.should_spawn_instance(0).await);
+        assert!(pool.should_spawn_instance(1).await);
+    }
+
+    #[tokio::test]
+    async fn test_should_spawn_instance_at_max_capacity() {
+        let pool = InstancePool::new(2);
+
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+        pool.add_instance(FunctionInstance::new(id1)).await;
+        pool.add_instance(FunctionInstance::new(id2)).await;
+
+        assert!(!pool.should_spawn_instance(5).await);
+    }
+
+    #[tokio::test]
+    async fn test_should_spawn_instance_with_idle() {
+        let pool = InstancePool::new(3);
+
+        let id = Uuid::new_v4();
+        let mut instance = FunctionInstance::new(id);
+        instance.status = InstanceStatus::Idle;
+        pool.add_instance(instance).await;
+
+        assert!(!pool.should_spawn_instance(1).await);
+    }
+
+    #[tokio::test]
+    async fn test_should_spawn_instance_all_busy() {
+        let pool = InstancePool::new(3);
+
+        let id = Uuid::new_v4();
+        let mut instance = FunctionInstance::new(id);
+        instance.status = InstanceStatus::Busy;
+        pool.add_instance(instance).await;
+
+        assert!(pool.should_spawn_instance(1).await);
+    }
+
+    #[tokio::test]
+    async fn test_mark_busy_and_idle() {
+        let pool = InstancePool::new(3);
+        let id = Uuid::new_v4();
+
+        pool.add_instance(FunctionInstance::new(id)).await;
+
+        pool.mark_idle(&id).await;
+        {
+            let instances = pool.instances.read().await;
+            let instance = instances.get(&id).unwrap();
+            assert_eq!(instance.status, InstanceStatus::Idle);
+        }
+
+        pool.mark_busy(&id).await;
+        {
+            let instances = pool.instances.read().await;
+            let instance = instances.get(&id).unwrap();
+            assert_eq!(instance.status, InstanceStatus::Busy);
+            assert_eq!(instance.requests_processed, 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_remove_instance() {
+        let pool = InstancePool::new(3);
+        let id = Uuid::new_v4();
+
+        pool.add_instance(FunctionInstance::new(id)).await;
+        assert_eq!(pool.instance_count().await, 1);
+
+        let removed = pool.remove_instance(&id).await;
+        assert!(removed.is_some());
+        assert_eq!(pool.instance_count().await, 0);
+    }
+}

--- a/crates/cargo-lambda-watch/src/trigger_router.rs
+++ b/crates/cargo-lambda-watch/src/trigger_router.rs
@@ -562,6 +562,7 @@ mod test {
             false,
             HashSet::new(),
             None,
+            1,
         ));
 
         let (func, path, _) = extract_path_parameters("", &Method::GET, &state);
@@ -611,6 +612,7 @@ mod test {
             false,
             HashSet::new(),
             Some(new_router),
+            1,
         ));
 
         let (func, path, _) = extract_path_parameters("/foo", &Method::GET, &state);
@@ -635,6 +637,7 @@ mod test {
             false,
             HashSet::new(),
             Some(new_router),
+            1,
         ));
 
         // Test with path parameters
@@ -664,6 +667,7 @@ mod test {
             false,
             HashSet::new(),
             config.watch.router,
+            1,
         ));
 
         // Test with path parameters and method

--- a/docs/commands/watch.md
+++ b/docs/commands/watch.md
@@ -141,6 +141,26 @@ You can pass a list of features separated by comma to the `watch` command to loa
 cargo lambda watch --features feature-1,feature-2
 ```
 
+## Concurrent invocations
+
+By default, `cargo lambda watch` processes Lambda invocations sequentially with a single function instance.
+You can enable concurrent request processing by specifying the maximum number of instances:
+
+```
+cargo lambda watch --concurrency 5
+```
+
+This will spawn up to 5 function instances dynamically based on demand, allowing multiple requests to be processed simultaneously. 
+This matches AWS Lambda's behavior with [managed instances](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-response-streaming/).
+
+### How it works
+
+- Instances are spawned on-demand when requests arrive and all current instances are busy
+- Each instance continuously polls for requests from a shared queue
+- Instances remain warm after processing requests (no repeated cold starts)
+- The concurrency limit is enforced globally per function
+- Each instance runs with `AWS_LAMBDA_MAX_CONCURRENCY=1` (single-worker mode)
+
 ## Debug with breakpoints
 
 You have two options to debug your application, set breakpoints, and step through your code using a debugger like GDB or LLDB.

--- a/tests/fixtures/single-binary-package/Cargo.toml
+++ b/tests/fixtures/single-binary-package/Cargo.toml
@@ -31,3 +31,6 @@ tags = { "organization" = "aws", "team" = "lambda" }
 type = "cargo"
 subcommand = ["brazil", "build"]
 extra_args = ["--release"]
+
+[package.metadata.lambda.watch]
+concurrency = 5

--- a/tests/fixtures/workspace-package/Cargo.toml
+++ b/tests/fixtures/workspace-package/Cargo.toml
@@ -7,6 +7,9 @@ AWS_REGION = "us-west-2"
 [workspace.metadata.lambda.bin.basic-lambda-1.env]
 EXTRA = "TRUE"
 
+[workspace.metadata.lambda.watch]
+concurrency = 3
+
 [workspace.metadata.lambda.watch.router]
 "/foo" = "crate-1"
 "/bar" = [


### PR DESCRIPTION
This allows to run multiple function instances concurrently. Allowing to mimic the behavior of aws lambda managed instances.

Fixes https://github.com/cargo-lambda/cargo-lambda/issues/754